### PR TITLE
fixed error creating client

### DIFF
--- a/sample.php
+++ b/sample.php
@@ -1,4 +1,5 @@
 <?php
+
 require 'vendor/autoload.php';
 
 use Moip\Moip;
@@ -34,8 +35,7 @@ $customer = $moip->customers()->setOwnId('sandbox_v2_1401147277')
                               ->setBirthDate('1988-12-30')
                               ->setTaxDocument('33333333333')
                               ->setPhone(11, 66778899);
-*/                              
+*/
 print_r($payment = $order->payments()
                  ->setCreditCard('05', '18', '4012001038443335', '123', $customer)
                  ->execute());
-

--- a/src/Moip/Http/AbstractHTTPRequest.php
+++ b/src/Moip/Http/AbstractHTTPRequest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Http;
 
-use \InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * Base para facilitar a implementação da interface HTTPRequest para uma
@@ -15,7 +16,7 @@ abstract class AbstractHTTPRequest implements HTTPRequest
     protected $httpResponse;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $openned = false;
 
@@ -52,7 +53,7 @@ abstract class AbstractHTTPRequest implements HTTPRequest
 
             if ($override === true || !isset($this->requestHeader[$key])) {
                 $this->requestHeader[$key] = array('name' => $name,
-                    'value' => $value
+                    'value' => $value,
                 );
 
                 return true;
@@ -68,6 +69,7 @@ abstract class AbstractHTTPRequest implements HTTPRequest
      * Autentica uma requisição HTTP.
      *
      * @param HTTPAuthenticator $authenticator
+     *
      * @see HTTPRequest::authenticate()
      */
     public function authenticate(HTTPAuthenticator $authenticator)
@@ -88,11 +90,13 @@ abstract class AbstractHTTPRequest implements HTTPRequest
      * par nome-valor que será enviado como uma query string.
      *
      * @param string $name
-     *            Nome do parâmetro.
+     *                      Nome do parâmetro.
      * @param string $value
-     *            Valor do parâmetro.
+     *                      Valor do parâmetro.
+     *
      * @throws InvalidArgumentException Se o nome ou o valor do campo não forem
-     *         valores scalar.
+     *                                  valores scalar.
+     *
      * @see HTTPRequest::setParameter()
      */
     public function setParameter($name, $value)

--- a/src/Moip/Http/CURL.php
+++ b/src/Moip/Http/CURL.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Moip\Http;
 
-use \RuntimeException;
-use \UnexpectedValueException;
+use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * Requisição HTTP cURL.
@@ -37,7 +38,7 @@ class CURL extends AbstractHTTPRequest
      */
     public function execute($path = '/', $method = HTTPRequest::GET)
     {
-        $targetURL = $this->httpConnection->getURI() . $path;
+        $targetURL = $this->httpConnection->getURI().$path;
         $hasParameters = count($this->requestParameter) > 0;
         $query = $hasParameters ? http_build_query($this->requestParameter) : null;
 
@@ -55,7 +56,7 @@ class CURL extends AbstractHTTPRequest
                     curl_setopt($this->curlResource, CURLOPT_POSTFIELDS, $query);
                 } else {
                     if ($hasParameters) {
-                        $targetURL .= '?' . $query;
+                        $targetURL .= '?'.$query;
                     }
 
                     curl_setopt($this->curlResource, CURLOPT_POSTFIELDS,
@@ -72,7 +73,7 @@ class CURL extends AbstractHTTPRequest
                 curl_setopt($this->curlResource, CURLOPT_CUSTOMREQUEST, $method);
             case HTTPRequest::GET :
                 if ($hasParameters) {
-                    $targetURL .= '?' . $query;
+                    $targetURL .= '?'.$query;
                 }
 
                 curl_setopt($this->curlResource, CURLOPT_URL, $targetURL);
@@ -114,14 +115,14 @@ class CURL extends AbstractHTTPRequest
     public function open(HTTPConnection $httpConnection)
     {
         if (function_exists('curl_init')) {
-            /**
+            /*
              * Fechamos uma conexão existente antes de abrir uma nova
              */
             $this->close();
 
             $curl = curl_init();
 
-            /**
+            /*
              * Verificamos se o recurso CURL foi criado com êxito
              */
             if (is_resource($curl)) {
@@ -142,7 +143,7 @@ class CURL extends AbstractHTTPRequest
 
                 $headers = array();
 
-                foreach ( $this->requestHeader as $header ) {
+                foreach ($this->requestHeader as $header) {
                     $headers[] = sprintf('%s: %s', $header['name'],
                         $header['value']);
                 }

--- a/src/Moip/Http/Cookie.php
+++ b/src/Moip/Http/Cookie.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Http;
 
-use \InvalidArgumentException;
+use InvalidArgumentException;
 
 /**
  * Implementação de um cookie HTTP segundo a especificação RFC 2109.
@@ -9,35 +10,35 @@ use \InvalidArgumentException;
 class Cookie
 {
     /**
-     * Comentário opcional do cookie
+     * Comentário opcional do cookie.
      *
      * @var string
      */
     protected $comment;
 
     /**
-     * Domínio do cookie
+     * Domínio do cookie.
      *
      * @var string
      */
     protected $domain;
 
     /**
-     * Expiração do cookie (unix timestamp)
+     * Expiração do cookie (unix timestamp).
      *
-     * @var integer
+     * @var int
      */
     protected $expires;
 
     /**
-     * Nome do cookie
+     * Nome do cookie.
      *
      * @var string
      */
     protected $name;
 
     /**
-     * Caminho do cookie
+     * Caminho do cookie.
      *
      * @var string
      */
@@ -46,36 +47,37 @@ class Cookie
     /**
      * Ambiente seguro (HTTPS).
      * Indica se o User-Agent deve utilizar o cookie
-     * apenas em ambiente seguro (HTTPS)
+     * apenas em ambiente seguro (HTTPS).
      *
-     * @var boolean
+     * @var bool
      */
     protected $secure;
 
     /**
-     * Valor do cookie
+     * Valor do cookie.
      *
      * @var string
      */
     protected $value;
 
     /**
-     * Constroi um cookie
+     * Constroi um cookie.
      *
      * @param string $name
-     *            Nome do cookie
+     *                        Nome do cookie
      * @param string $value
-     *            Valor do cookie
+     *                        Valor do cookie
      * @param string $domain
-     *            Domínio do cookie
-     * @param integer $expires
-     *            Timestamp da expiração do cookie
+     *                        Domínio do cookie
+     * @param int    $expires
+     *                        Timestamp da expiração do cookie
      * @param string $path
-     *            Caminho do cookie
-     * @param boolean $secure
-     *            Se o cookie é usado apenas em ambiente seguro.
+     *                        Caminho do cookie
+     * @param bool   $secure
+     *                        Se o cookie é usado apenas em ambiente seguro.
      * @param string $comment
-     *            Comentário do cookie
+     *                        Comentário do cookie
+     *
      * @throws InvalidArgumentException Se $expires não for um número
      */
     public function __construct($name, $value, $domain, $expires, $path = '/',
@@ -129,7 +131,7 @@ class Cookie
     /**
      * Recupera o timestamp da expiração do cookie.
      *
-     * @return integer
+     * @return int
      */
     public function getExpires()
     {
@@ -171,7 +173,7 @@ class Cookie
      * Verifica se o User-Agent deve utilizar o
      * cookie apenas em ambiente seguro.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSecure()
     {

--- a/src/Moip/Http/CookieManager.php
+++ b/src/Moip/Http/CookieManager.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Http;
 
-use \Serializable;
+use Serializable;
 
 /**
  * Interface para definição de um gerenciador de cookies.
@@ -19,14 +20,15 @@ interface CookieManager extends Serializable
      * Recupera os cookies armazenados para um determinado domínio.
      *
      * @param string $domain
-     *            Domínio dos cookies.
-     * @param boolean $secure
-     *            Indica ambiente seguro (https).
+     *                       Domínio dos cookies.
+     * @param bool   $secure
+     *                       Indica ambiente seguro (https).
      * @param string $path
-     *            Caminho dos cookies.
+     *                       Caminho dos cookies.
+     *
      * @return string O valor retornado segue o padrão especificado pela
-     *         RFC 2965 para ser utilizado diretamente no campo de cabeçalho
-     *         Cookie.
+     *                RFC 2965 para ser utilizado diretamente no campo de cabeçalho
+     *                Cookie.
      */
     public function getCookie($domain, $secure, $path);
 
@@ -34,11 +36,12 @@ interface CookieManager extends Serializable
      * Recupera uma lista com os cookies gerenciados.
      *
      * @param string $domain
-     *            Domínio dos cookies.
-     * @param boolean $secure
-     *            Indica ambiente seguro.
+     *                       Domínio dos cookies.
+     * @param bool   $secure
+     *                       Indica ambiente seguro.
      * @param string $path
-     *            Caminho dos cookies.
+     *                       Caminho dos cookies.
+     *
      * @return Iterator
      */
     public function getCookieIterator($domain, $secure, $path);

--- a/src/Moip/Http/HTTPAuthenticator.php
+++ b/src/Moip/Http/HTTPAuthenticator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip\Http;
 
 /**

--- a/src/Moip/Http/HTTPConnection.php
+++ b/src/Moip/Http/HTTPConnection.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Moip\Http;
 
-use \BadMethodCallException;
-use \InvalidArgumentException;
+use BadMethodCallException;
+use InvalidArgumentException;
 
 /**
  * Implementação de um conector HTTP.
@@ -24,73 +25,61 @@ class HTTPConnection
     const HTTPS_PORT = 443;
 
     /**
-     *
      * @var HTTPAuthenticator
      */
     protected $httpAuthenticator;
 
     /**
-     *
      * @var CookieManager
      */
     protected $cookieManager;
 
     /**
-     *
-     * @var integer
+     * @var int
      */
     protected $connectionTimeout;
 
     /**
-     *
      * @var string
      */
     protected $hostname;
 
     /**
-     *
-     * @var boolean
+     * @var bool
      */
     protected $initialized = false;
 
     /**
-     *
-     * @var integer
+     * @var int
      */
     protected $port;
 
     /**
-     *
      * @var string
      */
     protected $requestBody;
 
     /**
-     *
      * @var array
      */
     protected $requestHeader;
 
     /**
-     *
      * @var array
      */
     protected $requestParameter;
 
     /**
-     *
-     * @var boolean
+     * @var bool
      */
     protected $secure;
 
     /**
-     *
-     * @var integer
+     * @var int
      */
     protected $timeout;
 
     /**
-     *
      * @var string
      */
     protected static $userAgent;
@@ -122,15 +111,16 @@ class HTTPConnection
      * Adiciona um campo de cabeçalho para ser enviado com a requisição.
      *
      * @param string $name
-     *            Nome do campo de cabeçalho.
+     *                         Nome do campo de cabeçalho.
      * @param string $value
-     *            Valor do campo de cabeçalho.
-     * @param boolean $override
-     *            Indica se o campo deverá ser sobrescrito caso
-     *            já tenha sido definido.
+     *                         Valor do campo de cabeçalho.
+     * @param bool   $override
+     *                         Indica se o campo deverá ser sobrescrito caso
+     *                         já tenha sido definido.
+     *
      * @throws InvalidArgumentException Se o nome ou o valor do campo não forem
-     *         valores scalar.
-     *         @FIXME
+     *                                  valores scalar.
+     * @FIXME
      */
     public function addHeader($name, $value, $override = true)
     {
@@ -139,7 +129,7 @@ class HTTPConnection
 
             if ($override === true || !isset($this->requestHeader[$key])) {
                 $this->requestHeader[$key] = array('name' => $name,
-                    'value' => $value
+                    'value' => $value,
                 );
 
                 return true;
@@ -194,12 +184,14 @@ class HTTPConnection
      * método específico.
      *
      * @param string $path
-     *            Caminho da requisição.
+     *                       Caminho da requisição.
      * @param string $method
-     *            Método da requisição.
+     *                       Método da requisição.
+     *
      * @return paypal\http\HTTPResponse Resposta HTTP.
+     *
      * @throws BadMethodCallException Se não houver uma conexão inicializada ou
-     *         se o objeto de requisição não for válido.
+     *                                se o objeto de requisição não for válido.
      */
     public function execute($path = '/', $method = HTTPRequest::GET)
     {
@@ -236,7 +228,7 @@ class HTTPConnection
                 $request->authenticate($this->httpAuthenticator);
             }
 
-            foreach ( $this->requestHeader as $header ) {
+            foreach ($this->requestHeader as $header) {
                 $request->addRequestHeader($header['name'], $header['value']);
             }
 
@@ -247,7 +239,7 @@ class HTTPConnection
                     $this->isSecure(), $path);
 
                 if (isset($this->requestHeader['cookie'])) {
-                    $buffer = $this->requestHeader['cookie']['value'] . '; ' .
+                    $buffer = $this->requestHeader['cookie']['value'].'; '.
                          $cookies;
                 } else {
                     $buffer = $cookies;
@@ -256,7 +248,7 @@ class HTTPConnection
                 $request->addRequestHeader('Cookie', $buffer);
             }
 
-            foreach ( $this->requestParameter as $name => $value ) {
+            foreach ($this->requestParameter as $name => $value) {
                 $request->setParameter($name, $value);
             }
 
@@ -264,8 +256,8 @@ class HTTPConnection
 
             if ($path == null || !is_string($path) || empty($path)) {
                 $path = '/';
-            } else if (substr($path, 0, 1) != '/') {
-                $path = '/' . $path;
+            } elseif (substr($path, 0, 1) != '/') {
+                $path = '/'.$path;
             }
 
             if ($this->timeout != null) {
@@ -288,7 +280,7 @@ class HTTPConnection
     /**
      * Recupera o timeout de conexão.
      *
-     * @return integer
+     * @return int
      */
     public function getConnectionTimeout()
     {
@@ -309,6 +301,7 @@ class HTTPConnection
      * Recupera o host da conexão.
      *
      * @return string
+     *
      * @throws BadMethodCallException Se a conexão não tiver sido inicializada.
      */
     public function getHost()
@@ -316,10 +309,9 @@ class HTTPConnection
         if ($this->initialized) {
             $hostname = $this->getHostName();
 
-            if (($this->secure && $this->port != HTTPConnection::HTTPS_PORT) ||
-                 (!$this->secure && $this->port != HTTPConnection::HTTP_PORT)) {
-
-                $hostname .= ':' . $this->port;
+            if (($this->secure && $this->port != self::HTTPS_PORT) ||
+                 (!$this->secure && $this->port != self::HTTP_PORT)) {
+                $hostname .= ':'.$this->port;
             }
 
             return $hostname;
@@ -332,6 +324,7 @@ class HTTPConnection
      * Recupera o nome do host.
      *
      * @return string
+     *
      * @throws BadMethodCallException Se não houver uma conexão inicializada.
      */
     public function getHostName()
@@ -346,7 +339,8 @@ class HTTPConnection
     /**
      * Recupera a porta que será utilizada na conexão.
      *
-     * @return integer
+     * @return int
+     *
      * @throws BadMethodCallException Se não houver uma conexão inicializada.
      */
     public function getPort()
@@ -361,7 +355,7 @@ class HTTPConnection
     /**
      * Recupera o timeout.
      *
-     * @return integer
+     * @return int
      */
     public function getTimeout()
     {
@@ -372,6 +366,7 @@ class HTTPConnection
      * Recupera a URI que será utilizada na conexão.
      *
      * @return string
+     *
      * @throws BadMethodCallException Se não houver uma conexão inicializada.
      */
     public function getURI()
@@ -388,18 +383,18 @@ class HTTPConnection
      * Inicializa a conexão HTTP.
      *
      * @param string $hostname
-     *            Servidor que receberá a requisição.
-     * @param boolean $secure
-     *            Indica se a conexão será segura (https).
-     * @param integer $port
-     *            Porta da requisição.
-     * @param integer $connectionTimeout
-     *            Timeout de conexão em segundos.
-     * @param integer $timeout
-     *            Timeout de espera em segundos.
+     *                                  Servidor que receberá a requisição.
+     * @param bool   $secure
+     *                                  Indica se a conexão será segura (https).
+     * @param int    $port
+     *                                  Porta da requisição.
+     * @param int    $connectionTimeout
+     *                                  Timeout de conexão em segundos.
+     * @param int    $timeout
+     *                                  Timeout de espera em segundos.
      */
     public function initialize($hostname, $secure = false,
-                            $port = HTTPConnection::HTTP_PORT, $connectionTimeout = 0, $timeout = 0)
+                            $port = self::HTTP_PORT, $connectionTimeout = 0, $timeout = 0)
     {
         if ($this->initialized) {
             $this->close();
@@ -410,7 +405,7 @@ class HTTPConnection
         $this->secure = $secure === true;
 
         if (func_num_args() == 2) {
-            $this->port = $this->secure ? HTTPConnection::HTTPS_PORT : HTTPConnection::HTTP_PORT;
+            $this->port = $this->secure ? self::HTTPS_PORT : self::HTTP_PORT;
         } else {
             $this->port = (int) $port;
         }
@@ -422,7 +417,7 @@ class HTTPConnection
     /**
      * Verifica se é uma conexão segura.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSecure()
     {
@@ -452,9 +447,10 @@ class HTTPConnection
     /**
      * Define o timeout de conexão.
      *
-     * @param integer $connectionTimeout
+     * @param int $connectionTimeout
+     *
      * @throws InvalidArgumentException Se $connectionTimeout não for um
-     *         inteiro.
+     *                                  inteiro.
      */
     public function setConnectionTimeout($connectionTimeout)
     {
@@ -481,11 +477,12 @@ class HTTPConnection
      * par nome-valor que será enviado como uma query string.
      *
      * @param string $name
-     *            Nome do parâmetro.
+     *                      Nome do parâmetro.
      * @param string $value
-     *            Valor do parâmetro.
+     *                      Valor do parâmetro.
+     *
      * @throws InvalidArgumentException Se o nome ou o valor do campo não forem
-     *         valores scalar.
+     *                                  valores scalar.
      */
     public function setParam($name, $value = null)
     {
@@ -509,7 +506,8 @@ class HTTPConnection
     /**
      * Define o timeout.
      *
-     * @param integer $timeout
+     * @param int $timeout
+     *
      * @throws InvalidArgumentException Se $timeout não for um inteiro.
      */
     public function setTimeout($timeout)

--- a/src/Moip/Http/HTTPCookieManager.php
+++ b/src/Moip/Http/HTTPCookieManager.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Moip\Http;
 
-use \ArrayIterator;
-use \RuntimeException;
+use ArrayIterator;
+use RuntimeException;
 
 /**
  * Gerenciador de Cookies HTTP.
@@ -26,9 +27,9 @@ class HTTPCookieManager implements CookieManager
      * Constroi o gerenciador de cookies que grava as informações em um arquivo.
      *
      * @param string $dirname
-     *            Diretório onde os cookies serão gravados, caso
-     *            não informado o diretório temporário do sistema será
-     *            utilizado.
+     *                        Diretório onde os cookies serão gravados, caso
+     *                        não informado o diretório temporário do sistema será
+     *                        utilizado.
      */
     public function __construct($dirname = null)
     {
@@ -37,21 +38,21 @@ class HTTPCookieManager implements CookieManager
         }
 
         if (is_readable($dirname) && is_writable($dirname)) {
-            $cookieFile = realpath($dirname) . '/cookie.jar';
+            $cookieFile = realpath($dirname).'/cookie.jar';
 
             if (!is_file($cookieFile)) {
                 touch($cookieFile);
             } else {
                 $cookieManager = unserialize(file_get_contents($cookieFile));
 
-                if ($cookieManager instanceof HTTPCookieManager) {
+                if ($cookieManager instanceof self) {
                     $this->cookies = $cookieManager->cookies;
                 }
             }
 
             $this->cookieFile = $cookieFile;
         } else {
-            throw new RuntimeException('Permission denied at ' . $dirname);
+            throw new RuntimeException('Permission denied at '.$dirname);
         }
     }
 
@@ -93,7 +94,7 @@ class HTTPCookieManager implements CookieManager
         $secure = $secure === true;
 
         if (isset($this->cookies[$domain])) {
-            foreach ( $this->cookies[$domain] as $cookie ) {
+            foreach ($this->cookies[$domain] as $cookie) {
                 if ($cookie->isSecure() == $secure && $cookie->getPath() == $path) {
                     $cookies[] = $cookie;
                 }
@@ -117,19 +118,18 @@ class HTTPCookieManager implements CookieManager
     public function setCookie($setCookie, $domain = null)
     {
         if (is_array($setCookie)) {
-            foreach ( $setCookie as $setCookieItem ) {
+            foreach ($setCookie as $setCookieItem) {
                 $this->setCookie($setCookieItem);
             }
         } else {
             $matches = array();
 
             if (preg_match(
-                '/(?<name>[^\=]+)\=(?<value>[^;]+)' .
-                     '(; expires=(?<expires>[^;]+))?' .
-                     '(; path=(?<path>[^;]+))?' . '(; domain=(?<domain>[^;]+))?' .
-                     '(; (?<secure>secure))?' . '(; (?<httponly>httponly))?/',
+                '/(?<name>[^\=]+)\=(?<value>[^;]+)'.
+                     '(; expires=(?<expires>[^;]+))?'.
+                     '(; path=(?<path>[^;]+))?'.'(; domain=(?<domain>[^;]+))?'.
+                     '(; (?<secure>secure))?'.'(; (?<httponly>httponly))?/',
                     $setCookie, $matches)) {
-
                 $cookieName = null;
                 $cookieValue = null;
                 $cookieExpires = INF;
@@ -137,7 +137,7 @@ class HTTPCookieManager implements CookieManager
                 $cookieDomain = $domain;
                 $cookieSecure = false;
 
-                foreach ( $matches as $key => $value ) {
+                foreach ($matches as $key => $value) {
                     if (!empty($value)) {
                         switch ($key) {
                             case 'name' :
@@ -191,8 +191,8 @@ class HTTPCookieManager implements CookieManager
         if (is_array($cookies)) {
             $now = time();
 
-            foreach ( $cookies as $domain => $domainCookies ) {
-                foreach ( $domainCookies as $cookie ) {
+            foreach ($cookies as $domain => $domainCookies) {
+                foreach ($domainCookies as $cookie) {
                     if ($cookie instanceof Cookie) {
                         if ($cookie->getExpires() > $now) {
                             if (!isset($this->cookies[$domain])) {

--- a/src/Moip/Http/HTTPRequest.php
+++ b/src/Moip/Http/HTTPRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip\Http;
 
 /**
@@ -7,56 +8,56 @@ namespace Moip\Http;
 interface HTTPRequest
 {
     /**
-     * RFC 2616 sec 9.9
+     * RFC 2616 sec 9.9.
      *
      * @var string
      */
     const CONNECT = 'CONNECT';
 
     /**
-     * RFC 2616 sec 9.7
+     * RFC 2616 sec 9.7.
      *
      * @var string
      */
     const DELETE = 'DELETE';
 
     /**
-     * RFC 2616 sec 9.3
+     * RFC 2616 sec 9.3.
      *
      * @var string
      */
     const GET = 'GET';
 
     /**
-     * RFC 2616 sec 9.4
+     * RFC 2616 sec 9.4.
      *
      * @var string
      */
     const HEAD = 'HEAD';
 
     /**
-     * RFC 2616 sec 9.2
+     * RFC 2616 sec 9.2.
      *
      * @var string
      */
     const OPTIONS = 'OPTIONS';
 
     /**
-     * RFC 2616 sec 9.5
+     * RFC 2616 sec 9.5.
      *
      * @var string
      */
     const POST = 'POST';
 
     /**
-     * RFC 2616 sec 9.6
+     * RFC 2616 sec 9.6.
      *
      * @var string
      */
     const PUT = 'PUT';
 
     /**
-     * RFC 2616 sec 9.8
+     * RFC 2616 sec 9.8.
      *
      * @var string
      */
@@ -66,14 +67,15 @@ interface HTTPRequest
      * Adiciona um campo de cabeçalho para ser enviado com a requisição.
      *
      * @param string $name
-     *            Nome do campo de cabeçalho.
+     *                         Nome do campo de cabeçalho.
      * @param string $value
-     *            Valor do campo de cabeçalho.
-     * @param boolean $override
-     *            Indica se o campo deverá ser sobrescrito caso
-     *            já tenha sido definido.
+     *                         Valor do campo de cabeçalho.
+     * @param bool   $override
+     *                         Indica se o campo deverá ser sobrescrito caso
+     *                         já tenha sido definido.
+     *
      * @throws InvalidArgumentException Se o nome ou o valor do campo não forem
-     *         valores scalar.
+     *                                  valores scalar.
      */
     public function addRequestHeader($name, $value, $override = true);
 
@@ -93,13 +95,15 @@ interface HTTPRequest
      * Executa a requisição HTTP em um caminho utilizando um método específico.
      *
      * @param string $method
-     *            Método da requisição.
+     *                       Método da requisição.
      * @param string $path
-     *            Alvo da requisição.
+     *                       Alvo da requisição.
+     *
      * @return string Resposta HTTP.
+     *
      * @throws BadMethodCallException Se não houver uma conexão inicializada.
      */
-    public function execute($path = '/', $method = HTTPRequest::GET);
+    public function execute($path = '/', $method = self::GET);
 
     /**
      * Recupera a resposta da requisição.
@@ -112,8 +116,8 @@ interface HTTPRequest
      * Abre a requisição.
      *
      * @param HTTPConnection $httpConnection
-     *            Conexão HTTP relacionada com essa
-     *            requisição
+     *                                       Conexão HTTP relacionada com essa
+     *                                       requisição
      */
     public function open(HTTPConnection $httpConnection);
 
@@ -122,11 +126,12 @@ interface HTTPRequest
      * par nome-valor que será enviado como uma query string.
      *
      * @param string $name
-     *            Nome do parâmetro.
+     *                      Nome do parâmetro.
      * @param string $value
-     *            Valor do parâmetro.
+     *                      Valor do parâmetro.
+     *
      * @throws InvalidArgumentException Se o nome ou o valor do campo não forem
-     *         valores scalar.
+     *                                  valores scalar.
      */
     public function setParameter($name, $value);
 

--- a/src/Moip/Http/HTTPResponse.php
+++ b/src/Moip/Http/HTTPResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip\Http;
 
 /**
@@ -17,7 +18,7 @@ class HTTPResponse
     private $responseBody;
 
     /**
-     * @var integer
+     * @var int
      */
     private $statusCode;
 
@@ -39,7 +40,7 @@ class HTTPResponse
     /**
      * Recupera o tamanho do corpo da resposta.
      *
-     * @return integer
+     * @return int
      */
     public function getContentLength()
     {
@@ -59,7 +60,7 @@ class HTTPResponse
     /**
      * Recupera o código de status da resposta do servidor.
      *
-     * @return integer
+     * @return int
      */
     public function getStatusCode()
     {
@@ -80,8 +81,9 @@ class HTTPResponse
      * Verifica se existe um cabeçalho de resposta HTTP.
      *
      * @param string $name
-     *            Nome do cabeçalho
-     * @return boolean
+     *                     Nome do cabeçalho
+     *
+     * @return bool
      */
     public function hasResponseHeader($name)
     {
@@ -92,7 +94,8 @@ class HTTPResponse
      * Recupera o valor um campo de cabeçalho da resposta HTTP.
      *
      * @param string $name
-     *            Nome do campo de cabeçalho.
+     *                     Nome do campo de cabeçalho.
+     *
      * @return string O valor do campo ou NULL se não estiver existir.
      */
     public function getHeader($name)
@@ -102,10 +105,9 @@ class HTTPResponse
         if (isset($this->responseHeader[$key])) {
             if (!isset($this->responseHeader[$key]['name']) &&
                  is_array($this->responseHeader[$key])) {
-
                 $values = array();
 
-                foreach ( $this->responseHeader[$key] as $header ) {
+                foreach ($this->responseHeader[$key] as $header) {
                     $values[] = $header['value'];
                 }
 
@@ -115,15 +117,16 @@ class HTTPResponse
             }
         }
 
-        return null;
+        return;
     }
 
     /**
      * Recupera um valor como inteiro de um campo de cabeçalho da resposta HTTP.
      *
      * @param string $name
-     *            Nome do campo de cabeçalho.
-     * @return integer
+     *                     Nome do campo de cabeçalho.
+     *
+     * @return int
      */
     public function getHeaderInt($name)
     {
@@ -136,8 +139,9 @@ class HTTPResponse
      * HTTP.
      *
      * @param string $name
-     *            Nome do campo de cabeçalho.
-     * @return integer UNIX Timestamp ou NULL se não estiver definido.
+     *                     Nome do campo de cabeçalho.
+     *
+     * @return int UNIX Timestamp ou NULL se não estiver definido.
      */
     public function getHeaderDate($name)
     {
@@ -152,7 +156,7 @@ class HTTPResponse
      * Define a resposta da requisição HTTP.
      *
      * @param string $response
-     *            Toda a resposta da requisição
+     *                         Toda a resposta da requisição
      */
     public function setRawResponse($response,
                                 CookieManager $cookieManager = null)
@@ -164,11 +168,10 @@ class HTTPResponse
             $this->responseBody = $parts[1];
 
             if (preg_match_all(
-                '/(HTTP\/[1-9]\.[0-9]\s+(?<statusCode>\d+)\s+(?<statusMessage>.*)' .
+                '/(HTTP\/[1-9]\.[0-9]\s+(?<statusCode>\d+)\s+(?<statusMessage>.*)'.
                      "|(?<headerName>[^:]+)\\s*:\\s*(?<headerValue>.*))\r\n/m",
                     $parts[0], $matches)) {
-
-                foreach ( $matches['statusCode'] as $offset => $match ) {
+                foreach ($matches['statusCode'] as $offset => $match) {
                     if (!empty($match)) {
                         $this->statusCode = (int) $match;
                         $this->statusMessage = $matches['statusMessage'][$offset];
@@ -176,17 +179,17 @@ class HTTPResponse
                     }
                 }
 
-                foreach ( $matches['headerName'] as $offset => $name ) {
+                foreach ($matches['headerName'] as $offset => $name) {
                     if (!empty($name)) {
                         $key = strtolower($name);
                         $header = array('name' => $name,
-                            'value' => $matches['headerValue'][$offset]
+                            'value' => $matches['headerValue'][$offset],
                         );
 
                         if (isset($this->responseHeader[$key])) {
                             if (isset($this->responseHeader[$key]['name'])) {
                                 $this->responseHeader[$key] = array(
-                                    $this->responseHeader[$key]
+                                    $this->responseHeader[$key],
                                 );
                             }
 

--- a/src/Moip/Moip.php
+++ b/src/Moip/Moip.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Moip;
 
 use Moip\Http\HTTPConnection;
-use Moip\Http\BasicAuthentication;
 use Moip\Resource\Orders;
 use Moip\Resource\Customer;
 use Moip\Resource\Payment;
@@ -13,54 +13,54 @@ class Moip
 {
     const PRODUCTION_ENDPOINT = 'moip.com.br';
     const SANDBOX_ENDPOINT = 'test.moip.com.br';
-    
+
     /**
      * @var MoipAuthentication
      */
     private $moipAuthentication;
-    
+
     /**
      * @var string
      */
-    private $endpoint = Moip::PRODUCTION_ENDPOINT;
-    
+    private $endpoint = self::PRODUCTION_ENDPOINT;
+
     public function __construct(MoipAuthentication $moipAuthentication,
-                                $endpoint = Moip::PRODUCTION_ENDPOINT)
+                                $endpoint = self::PRODUCTION_ENDPOINT)
     {
         $this->moipAuthentication = $moipAuthentication;
         $this->endpoint = $endpoint;
     }
-    
+
     public function createConnection()
     {
         $httpConnection = new HTTPConnection('Moip SDK');
         $httpConnection->initialize($this->endpoint, true);
         $httpConnection->addHeader('Accept', 'application/json');
-		$httpConnection->setAuthenticator($this->moipAuthentication);
+        $httpConnection->setAuthenticator($this->moipAuthentication);
 
         return $httpConnection;
     }
-    
+
     public function customers()
     {
         return new Customer($this);
     }
-    
+
     public function entries()
     {
         return new Entry($this);
     }
-    
+
     public function orders()
     {
         return new Orders($this);
     }
-    
+
     public function payments()
     {
         return new Payment($this);
     }
-    
+
     public function multiorders()
     {
         return new Multiorders($this);

--- a/src/Moip/MoipAuthentication.php
+++ b/src/Moip/MoipAuthentication.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip;
 
 use Moip\Http\HTTPAuthenticator;

--- a/src/Moip/MoipBasicAuth.php
+++ b/src/Moip/MoipBasicAuth.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip;
 
 use Moip\Http\HTTPRequest;
@@ -7,13 +8,13 @@ class MoipBasicAuth implements MoipAuthentication
 {
     private $token;
     private $key;
-    
+
     public function __construct($token, $key)
     {
         $this->token = $token;
         $this->key = $key;
     }
-    
+
     /**
      * Autentica uma requisição HTTP.
      *
@@ -22,6 +23,6 @@ class MoipBasicAuth implements MoipAuthentication
     public function authenticate(HTTPRequest $httpRequest)
     {
         $httpRequest->addRequestHeader('Authorization',
-                                       'Basic ' . base64_encode($this->token . ':' . $this->key));
+                                       'Basic '.base64_encode($this->token.':'.$this->key));
     }
 }

--- a/src/Moip/MoipOAuth.php
+++ b/src/Moip/MoipOAuth.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Moip;
 
 use Moip\Http\HTTPRequest;
@@ -9,12 +10,12 @@ class MoipOAuth implements MoipAuthentication
      * @var string
      */
     private $accessToken;
-    
+
     public function __construct($accessToken)
     {
         $this->accessToken = $accessToken;
     }
-    
+
     /**
      * Autentica uma requisição HTTP.
      *
@@ -23,6 +24,6 @@ class MoipOAuth implements MoipAuthentication
     public function authenticate(HTTPRequest $httpRequest)
     {
         $httpRequest->addRequestHeader('Authorization',
-                                       'OAuth ' . $this->accessToken);
+                                       'OAuth '.$this->accessToken);
     }
 }

--- a/src/Moip/Resource/Customer.php
+++ b/src/Moip/Resource/Customer.php
@@ -106,6 +106,19 @@ class Customer extends MoipResource
     {
         return $this->getIfSet('number', $this->data->taxDocument);
     }
+
+    private function getAddresses(stdClass $response)
+    {
+        if (isset($response->shippingAddress)) {
+            $response->addresses[] = $response->shippingAddress;
+        }
+
+        if (isset($response->billingAddress)) {
+            $response->addresses[] = $response->billingAddress;
+        }
+
+        return $response->addresses;
+    }
     
     protected function populate(stdClass $response)
     {
@@ -124,6 +137,8 @@ class Customer extends MoipResource
         $customer->data->taxDocument->type = $this->getIfSet('type', $response->taxDocument);
         $customer->data->taxDocument->number = $this->getIfSet('number', $response->taxDocument);
         $customer->data->addresses = array();
+
+        $response->addresses = $this->getAddresses($response);
         
         foreach ($response->addresses as $responseAddress) {
             $address = new stdClass();

--- a/src/Moip/Resource/Customer.php
+++ b/src/Moip/Resource/Customer.php
@@ -1,17 +1,17 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 use Moip\Http\HTTPRequest;
 
 class Customer extends MoipResource
-{   
+{
     public function initialize()
     {
         $this->data = new stdClass();
-
     }
-    
+
     public function addAddress($type, $street, $number, $district, $city, $state, $zip, $complement = null, $country = 'BRA')
     {
         $address = new stdClass();
@@ -24,84 +24,84 @@ class Customer extends MoipResource
         $address->state = $state;
         $address->country = $country;
         $address->zipCode = $zip;
-        
+
         $this->data->addresses[] = $address;
-        
+
         return $this;
     }
-    
+
     public function create()
-    {        
+    {
         $body = json_encode($this);
-        
+
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
         $httpConnection->addHeader('Content-Length', strlen($body));
         $httpConnection->setRequestBody($body);
-        
+
         $httpResponse = $httpConnection->execute('/v2/customers', HTTPRequest::POST);
-        
+
         if ($httpResponse->getStatusCode() != 201) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function get($id)
-    {   
+    {
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
-        
+
         $httpResponse = $httpConnection->execute('/v2/customers/'.$id, HTTPRequest::GET);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function getId()
     {
         return $this->getIfSet('id');
     }
-    
+
     public function getFullname()
     {
         return $this->getIfSet('fullname');
     }
-    
+
     public function getFundingInstrument()
     {
         return $this->getIfSet('fundingInstrument');
     }
-    
+
     public function getBirthDate()
     {
         return $this->getIfSet('birthDate');
     }
-    
+
     public function getPhoneAreaCode()
     {
         return $this->getIfSet('areaCode', $this->data->phone);
     }
-    
+
     public function getPhoneCountryCode()
     {
         return $this->getIfSet('countryCode', $this->data->phone);
     }
-    
+
     public function getPhoneNumber()
     {
         return $this->getIfSet('number', $this->data->phone);
     }
-    
+
     public function getTaxDocumentType()
     {
         return $this->getIfSet('type', $this->data->taxDocument);
     }
-    
+
     public function getTaxDocumentNumber()
     {
         return $this->getIfSet('number', $this->data->taxDocument);
@@ -119,7 +119,7 @@ class Customer extends MoipResource
 
         return $response->addresses;
     }
-    
+
     protected function populate(stdClass $response)
     {
         $customer = clone $this;
@@ -139,7 +139,7 @@ class Customer extends MoipResource
         $customer->data->addresses = array();
 
         $response->addresses = $this->getAddresses($response);
-        
+
         foreach ($response->addresses as $responseAddress) {
             $address = new stdClass();
             $address->type = $this->getIfSet('type', $responseAddress);
@@ -151,46 +151,46 @@ class Customer extends MoipResource
             $address->state = $this->getIfSet('state', $responseAddress);
             $address->country = $this->getIfSet('country', $responseAddress);
             $address->zipCode = $this->getIfSet('zipCode', $responseAddress);
-            
+
             $customer->data->addresses[] = $address;
         }
-        
+
         $customer->data->_links = $this->getIfSet('_links', $response);
-        
+
         if (isset($response->fundingInstrument)) {
             $customer->data->fundingInstrument = $response->fundingInstrument;
         }
-        
+
         return $customer;
     }
-    
+
     public function setOwnId($ownId)
     {
         $this->data->ownId = $ownId;
-        
+
         return $this;
     }
-    
+
     public function setFullname($fullname)
     {
         $this->data->fullname = $fullname;
-        
+
         return $this;
     }
-    
+
     public function setEmail($email)
     {
         $this->data->email = $email;
-        
+
         return $this;
     }
-    
+
     public function setCreditCard($expirationMonth, $expirationYear, $number, $cvc, Customer $holder = null)
     {
         if ($holder === null) {
             $holder = $this;
         }
-        
+
         $this->data->fundingInstrument = new stdClass();
         $this->data->fundingInstrument->method = 'CREDIT_CARD';
         $this->data->fundingInstrument->creditCard = new stdClass();
@@ -208,33 +208,33 @@ class Customer extends MoipResource
         $this->data->fundingInstrument->creditCard->holder->phone->countryCode = $holder->getPhoneCountryCode();
         $this->data->fundingInstrument->creditCard->holder->phone->areaCode = $holder->getPhoneAreaCode();
         $this->data->fundingInstrument->creditCard->holder->phone->number = $holder->getPhoneNumber();
-        
+
         return $this;
     }
-    
+
     public function setBirthDate($birthDate)
     {
         $this->data->birthDate = $birthDate;
-        
+
         return $this;
     }
-    
+
     public function setTaxDocument($number, $type = 'CPF')
     {
         $this->data->taxDocument = new stdClass();
         $this->data->taxDocument->type = $type;
         $this->data->taxDocument->number = $number;
-        
+
         return $this;
     }
-    
+
     public function setPhone($areaCode, $number, $countryCode = 55)
     {
         $this->data->phone = new stdClass();
         $this->data->phone->countryCode = $countryCode;
         $this->data->phone->areaCode = $areaCode;
         $this->data->phone->number = $number;
-        
+
         return $this;
     }
 }

--- a/src/Moip/Resource/Entry.php
+++ b/src/Moip/Resource/Entry.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 use Moip\Http\HTTPRequest;
 
 class Entry extends MoipResource
@@ -13,110 +14,110 @@ class Entry extends MoipResource
         $this->data->details = new stdClass();
         $this->data->parentPayments = new stdClass();
     }
-    
+
     protected function populate(stdClass $response)
     {
         $entry = clone $this;
-        
+
         $entry->data->id = $this->getIfSet('id', $response);
         $entry->data->status = $this->getIfSet('status', $response);
         $entry->data->operation = $this->getIfSet('operation', $response);
-        
+
         if (isset($response->amount)) {
             $entry->data->amount->total = $this->getIfSet('total', $response->amount);
             $entry->data->amount->fee = $this->getIfSet('fee', $response->amount);
             $entry->data->amount->liquid = $this->getIfSet('liquid', $response->amount);
             $entry->data->amount->currency = $this->getIfSet('currency', $response->amount);
         }
-        
+
         if (isset($response->details)) {
             $entry->data->details = $this->getIfSet('details', $response);
         }
-        
+
         if (isset($response->{'parent'}) && isset($response->{'parent'}->payments)) {
             $payments = new Payment($entry->moip);
             $payments->populate($response->{'parent'}->payments);
-            
+
             $entry->data->parentPayments = $payments;
         }
-        
+
         return $entry;
     }
-    
+
     public function get($id)
-    {   
+    {
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
-        
+
         $httpResponse = $httpConnection->execute('/v2/entries/'.$id, HTTPRequest::GET);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function getId()
     {
         return $this->getIfSet('id');
     }
-    
+
     public function getStatus()
     {
         return $this->getIfSet('status');
     }
-    
+
     public function getOperation()
     {
         return $this->getIfSet('operation');
     }
-    
+
     public function getAmountTotal()
     {
         return $this->getIfSet('total', $this->data->amount);
     }
-    
+
     public function getAmountFee()
     {
         return $this->getIfSet('fee', $this->data->amount);
     }
-    
+
     public function getAmountLiquid()
     {
         return $this->getIfSet('liquid', $this->data->amount);
     }
-    
+
     public function getAmountCurrency()
     {
         return $this->getIfSet('currency', $this->data->amount);
     }
-    
+
     public function getDetails()
     {
         return $this->getIfSet('details');
     }
-    
+
     public function getParentPayments()
     {
         return $this->getIfSet('parentPayments');
     }
-    
+
     public function getScheduledFor()
     {
         return $this->getIfSet('scheduledFor');
     }
-    
+
     public function getSettledAt()
     {
         return $this->getIfSet('settledAt');
     }
-    
+
     public function getUpdatedAt()
     {
         return $this->getIfSet('updatedAt');
     }
-    
+
     public function getCreatedAt()
     {
         return $this->getIfSet('createdAt');

--- a/src/Moip/Resource/Event.php
+++ b/src/Moip/Resource/Event.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 
 class Event extends MoipResource
 {
@@ -12,21 +13,22 @@ class Event extends MoipResource
         $this->data->createdAt = null;
         $this->data->descriotion = null;
     }
-    
+
     public function getType()
     {
         return $this->data->type;
     }
-    
+
     public function getCreatedAt()
     {
         return $this->data->createdAt;
     }
-    
-    public function getDescription(){
+
+    public function getDescription()
+    {
         return $this->data->description;
     }
-    
+
     protected function populate(stdClass $response)
     {
         $this->data = $response;

--- a/src/Moip/Resource/MoipResource.php
+++ b/src/Moip/Resource/MoipResource.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Moip\Resource;
 
 use Moip\Moip;
-use \stdClass;
+use stdClass;
 
 abstract class MoipResource implements \JsonSerializable
 {
@@ -10,41 +11,41 @@ abstract class MoipResource implements \JsonSerializable
      * @var Moip\Moip
      */
     protected $moip;
-    
+
     /**
      * @var \stdClass
      */
     protected $data;
-    
+
     public function __construct(Moip $moip)
     {
         $this->moip = $moip;
         $this->data = new stdClass();
         $this->initialize();
     }
-    
+
     protected function createConnection()
     {
         return $this->moip->createConnection();
     }
-    
+
     protected function getIfSet($key, stdClass $data = null)
     {
         if ($data == null) {
             $data = $this->data;
         }
-        
+
         if (isset($data->$key)) {
             return $data->$key;
         }
     }
-    
+
     abstract protected function initialize();
-    
+
     public function jsonSerialize()
     {
         return $this->data;
     }
-    
+
     abstract protected function populate(stdClass $response);
 }

--- a/src/Moip/Resource/Multiorders.php
+++ b/src/Moip/Resource/Multiorders.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 use Moip\Http\HTTPRequest;
 
 class Multiorders extends MoipResource
@@ -12,7 +13,7 @@ class Multiorders extends MoipResource
         $this->data->ownId = null;
         $this->data->orders = array();
     }
-    
+
     public function addOrder(Orders $order)
     {
         $this->data->orders[] = $order;
@@ -37,66 +38,66 @@ class Multiorders extends MoipResource
 
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function get($id)
     {
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
-        
+
         $httpResponse = $httpConnection->execute('/v2/multiorders/'.$id, HTTPRequest::GET);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function getId()
     {
         return $this->getIfSet('id');
     }
-    
+
     public function getOwnId()
     {
         return $this->getIfSet('ownId');
     }
-    
+
     public function getStatus()
     {
         return $this->getIfSet('status');
     }
-    
+
     public function getAmountTotal()
     {
         return $this->getIfSet('total', $this->data->amount);
     }
-    
+
     public function getAmountCurrency()
     {
         return $this->getIfSet('currency', $this->data->amount);
     }
-    
+
     public function getCreatedAt()
     {
         return $this->getIfSet('createdAt');
     }
-    
+
     public function getUpdatedAt()
     {
         return $this->getIfSet('updatedAt');
     }
-    
+
     public function getOrderIterator()
     {
         return new \ArrayIterator($this->getIfSet('orders'));
     }
-    
+
     public function multipayments()
     {
         $payments = new Payment($this->moip);
         $payments->setMultiorder($this);
-        
+
         return $payments;
     }
 
@@ -111,18 +112,18 @@ class Multiorders extends MoipResource
         $multiorders->data->amount->total = $response->amount->total;
         $multiorders->data->amount->currency = $response->amount->currency;
         $multiorders->data->orders = array();
-        
+
         foreach ($response->orders as $responseOrder) {
             $order = new Orders($multiorders->moip);
             $order->populate($responseOrder);
-            
+
             $multiorders->data->orders[] = $order;
         }
-        
+
         $multiorders->data->createdAt = $response->createdAt;
         $multiorders->data->updatedAt = $response->updatedAt;
         $multiorders->data->_links = $response->_links;
-        
+
         return $multiorders;
     }
 

--- a/src/Moip/Resource/Orders.php
+++ b/src/Moip/Resource/Orders.php
@@ -1,12 +1,12 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 use Moip\Http\HTTPRequest;
-use Moip\Http\HTTPResponse;
 
 class Orders extends MoipResource
-{   
+{
     public function addItem($product, $quantity, $detail, $price)
     {
         $item = new stdClass();
@@ -14,24 +14,24 @@ class Orders extends MoipResource
         $item->quantity = $quantity;
         $item->detail = $detail;
         $item->price = $price;
-        
+
         $this->data->items[] = $item;
-        
+
         return $this;
     }
-    
+
     public function addReceiver($moipAccount, $type = 'PRIMARY')
     {
         $receiver = new stdClass();
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
         $receiver->type = $type;
-        
+
         $this->data->receivers[] = $receiver;
-        
+
         return $this;
     }
-    
+
     protected function initialize()
     {
         $this->data = new stdClass();
@@ -41,16 +41,16 @@ class Orders extends MoipResource
         $this->data->items = array();
         $this->data->receivers = array();
     }
-    
+
     private function initializeSubtotals()
     {
         if (!isset($this->data->subtotals)) {
             $this->data->subtotals = new stdClass();
         }
-    }   
-    
+    }
+
     protected function populate(stdClass $response)
-    {   
+    {
         $orders = clone $this;
         $orders->data->id = $response->id;
         $orders->data->amount->total = $response->amount->total;
@@ -61,258 +61,258 @@ class Orders extends MoipResource
         $orders->data->amount->subtotals = $response->amount->subtotals;
         $orders->data->customer = new Customer($orders->moip);
         $orders->data->customer->populate($response->customer);
-        
+
         if (isset($response->payments)) {
             $orders->data->payments = array();
-        
+
             foreach ($response->payments as $responsePayment) {
                 $payment = new Payment($orders->moip);
                 $payment->populate($responsePayment);
                 $payment->setOrder($this);
-                
+
                 $orders->data->payments[] = $payment;
             }
         }
-        
+
         if (isset($response->refunds)) {
             $orders->data->refunds = array();
-        
+
             foreach ($response->refunds as $responseRefund) {
                 $refund = new Refund($orders->moip);
                 $refund->populate($responseRefund);
-                
+
                 $orders->data->refunds[] = $refund;
             }
         }
-        
+
         if (isset($response->entries)) {
             $orders->data->entries = array();
-        
+
             foreach ($response->entries as $responseEntry) {
                 $entry = new Entry($orders->moip);
                 $entry->populate($responseEntry);
-                
+
                 $orders->data->entries[] = $entry;
             }
         }
-        
+
         if (isset($response->events)) {
             $orders->data->events = array();
-        
+
             foreach ($response->events as $responseEvent) {
                 $event = new Event($orders->moip);
                 $event->populate($responseEvent);
-                
+
                 $orders->data->events[] = $event;
             }
         }
-        
+
         $orders->data->items = $response->items;
         $orders->data->receivers = $response->receivers;
         $orders->data->createdAt = $response->createdAt;
         $orders->data->_links = $response->_links;
-        
+
         return $orders;
     }
-    
+
     public function create()
-    {        
+    {
         $body = json_encode($this);
 
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
         $httpConnection->addHeader('Content-Length', strlen($body));
         $httpConnection->setRequestBody($body);
-        
+
         $httpResponse = $httpConnection->execute('/v2/orders', HTTPRequest::POST);
-        
+
         if ($httpResponse->getStatusCode() != 201) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function get($id)
     {
         $body = '{}';
-        
+
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
         $httpConnection->addHeader('Content-Length', strlen($body));
         $httpConnection->setRequestBody($body);
-        
+
         $httpResponse = $httpConnection->execute('/v2/orders/'.$id, HTTPRequest::GET);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     public function getId()
     {
         return $this->getIfSet('id');
     }
-    
+
     public function getOwnId()
     {
         return $this->getIfSet('ownId');
     }
-    
+
     public function getAmountTotal()
     {
         return $this->getIfSet('total', $this->data->amount);
     }
-    
+
     public function getAmountFees()
     {
         return $this->getIfSet('feed', $this->data->amount);
     }
-    
+
     public function getAmountRefunds()
     {
         return $this->getIfSet('refunds', $this->data->amount);
     }
-    
+
     public function getAmountLiquid()
     {
         return $this->getIfSet('liquid', $this->data->amount);
     }
-    
+
     public function getAmountOtherReceivers()
     {
         return $this->getIfSet('otherReceivers', $this->data->amount);
     }
-    
+
     public function getCurrenty()
     {
         return $this->getIfSet('currency', $this->data->amount);
     }
-    
+
     public function getSubtotalShipping()
     {
         $this->initializeSubtotals();
-        
+
         return $this->getIfSet('shipping', $this->data->amount->subtotals);
     }
-    
+
     public function getSubtotalAddition()
     {
         $this->initializeSubtotals();
-        
+
         return $this->getIfSet('addition', $this->data->amount->subtotals);
     }
-    
+
     public function getSubtotalDiscount()
     {
         $this->initializeSubtotals();
-        
+
         return $this->getIfSet('discount', $this->data->amount->subtotals);
     }
-    
+
     public function getSubtotalItems()
     {
         $this->initializeSubtotals();
-        
+
         return $this->getIfSet('items', $this->data->amount->subtotals);
     }
-    
+
     public function getItemIterator()
     {
         return new \ArrayIterator($this->data->items);
     }
-    
+
     public function getCustomer()
     {
         return $this->data->customer;
     }
-    
+
     public function getPaymentIterator()
     {
         return new \ArrayIterator($this->data->payments);
     }
-    
+
     public function getReceiverIterator()
     {
         return new \ArrayIterator($this->data->receivers);
     }
-    
+
     public function getEventIterator()
     {
         return new \ArrayIterator($this->data->events);
     }
-    
+
     public function getRefundIterator()
     {
         return new \ArrayIterator($this->data->refunds);
     }
-    
+
     public function getStatus()
     {
         return $this->getIfSet('status');
     }
-    
+
     public function getCreatedAt()
     {
         return $this->getIfSet('createdAt');
     }
-    
+
     public function getUpdatedAt()
     {
         return $this->getIfSet('updatedAt');
     }
-    
+
     public function getLinks()
     {
         return $this->getIfSet('_links');
     }
-    
+
     public function payments()
     {
         $payment = new Payment($this->moip);
         $payment->setOrder($this);
-        
+
         return $payment;
     }
-    
+
     public function refunds()
     {
         $refund = new Refund($this->moip);
         $refund->setOrder($this);
-        
+
         return $refund;
     }
-    
+
     public function setAddition($value)
-    {   
+    {
         $this->data->subtotals->addition = (float) $value;
-        
+
         return $this;
     }
-    
+
     public function setCustomer(Customer $customer)
     {
         $this->data->customer = $customer;
-        
+
         return $this;
     }
-    
+
     public function setDiscont($value)
     {
         $this->data->subtotals->discont = (float) $value;
-        
+
         return $this;
     }
-    
+
     public function setOwnId($ownId)
     {
         $this->data->ownId = $ownId;
-        
+
         return $this;
     }
-    
+
     public function setShippingAmount($value)
     {
         if (!isset($this->data->amount->subtotals)) {
@@ -320,7 +320,7 @@ class Orders extends MoipResource
         }
 
         $this->data->amount->subtotals->shipping = (float) $value;
-        
+
         return $this;
     }
 }

--- a/src/Moip/Resource/Refund.php
+++ b/src/Moip/Resource/Refund.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Moip\Resource;
 
-use \stdClass;
+use stdClass;
 use Moip\Http\HTTPRequest;
 
 class Refund extends MoipResource
@@ -10,37 +11,37 @@ class Refund extends MoipResource
      * @var \Moip\Orders
      */
     private $order;
-    
+
     /**
      * @var \Moip\Payment
      */
     private $payment;
-    
+
     public function initialize()
     {
         $this->data = new stdClass();
     }
-    
+
     protected function populate(stdClass $response)
     {
         $refund = clone $this;
-        
+
         $refund->data->id = $this->getIfSet('id', $response);
-        
+
         if (isset($response->amount)) {
             $refund->data->amount = new stdClass();
             $refund->data->amount->total = $this->getIfSet('total', $response->amount);
             $refund->data->amount->discounted = $this->getIfSet('discounted', $response->amount);
             $refund->data->amount->currency = $this->getIfSet('currency', $response->amount);
         }
-        
+
         $refund->data->fee = $this->getIfSet('fee', $response);
         $refund->data->createdAt = $this->getIfSet('createdAt', $response);
-        
+
         if (isset($response->refundingInstrument)) {
             $refund->data->refundingInstrument = new stdClass();
             $refund->data->refundingInstrument->method = $this->getIfSet('method', $response->refundingInstrument);
-            
+
             if (isset($response->refundingInstrument->bankAccount)) {
                 $refund->data->refundingInstrument->bankAccount = new stdClass();
                 $refund->data->refundingInstrument->bankAccount->bankNumber = $this->getIfSet('bankNumber', $response->refundingInstrument->bankAccount);
@@ -53,39 +54,39 @@ class Refund extends MoipResource
                 $refund->data->refundingInstrument->bankAccount->type = $this->getIfSet('type', $response->refundingInstrument->bankAccount);
             }
         }
-        
+
         $refund->data->status = $this->getIfSet('status', $response);
         $refund->data->method = $this->getIfSet('method', $response);
         $refund->data->createdAt = $this->getIfSet('createdAt', $response);
         $refund->data->_links = $this->getIfSet('_links', $response);
-        
+
         return $refund;
     }
-    
+
     private function execute(stdClass $data = null)
     {
-        $body = $data == null? '{}': json_encode($data);
-        
+        $body = $data == null ? '{}' : json_encode($data);
+
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
         $httpConnection->addHeader('Content-Length', strlen($body));
         $httpConnection->setRequestBody($body);
-        
+
         if ($this->order !== null) {
             $path = sprintf('/v2/orders/%s/refunds', $this->order->getId());
         } else {
             $path = sprintf('/v2/payments/%s/refunds', $this->payment->getId());
         }
-        
+
         $httpResponse = $httpConnection->execute($path, HTTPRequest::POST);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         return $this->populate(json_decode($httpResponse->getContent()));
     }
-    
+
     private function bankAccount($type, $bankNumber, $agencyNumber, $agencyCheckNumber, $accountNumber, $accountCheckNumber, Customer $holder)
     {
         $data = new stdClass();
@@ -102,70 +103,70 @@ class Refund extends MoipResource
         $data->bankAccount->holder->taxDocument = new stdClass();
         $data->bankAccount->holder->taxDocument->type = $holder->getTaxDocumentType();
         $data->bankAccount->holder->taxDocument->number = $holder->getTaxDocumentNumber();
-        
+
         return $data;
     }
-    
+
     public function bankAccountFull($type, $bankNumber, $agencyNumber, $agencyCheckNumber, $accountNumber, $accountCheckNumber, Customer $holder)
     {
         $data = $this->bankAccount($type, $bankNumber, $agencyNumber, $agencyCheckNumber, $accountNumber, $accountCheckNumber, $holder);
-        
+
         return $this->execute($data);
     }
-    
+
     public function bankAccountPartial($amount, $type, $bankNumber, $agencyNumber, $agencyCheckNumber, $accountNumber, $accountCheckNumber, Customer $holder)
     {
         $data = $this->bankAccount($type, $bankNumber, $agencyNumber, $agencyCheckNumber, $accountNumber, $accountCheckNumber, $holder);
         $data->amount = $amount;
-        
+
         return $this->execute($data);
     }
-    
+
     public function creditCardFull()
     {
         return $this->execute();
     }
-    
+
     public function creditCardPartial($amount)
     {
         $data = new stdClass();
         $data->amount = $amount;
-        
+
         return $this->execute($data);
     }
-    
+
     public function getIterator()
     {
         $httpConnection = $this->createConnection();
         $httpConnection->addHeader('Content-Type', 'application/json');
-        
+
         if ($this->order !== null) {
             $path = sprintf('/v2/orders/%s/refunds', $this->order->getId());
         } else {
             $path = sprintf('/v2/payments/%s/refunds', $this->payment->getId());
         }
-        
+
         $httpResponse = $httpConnection->execute($path, HTTPRequest::GET);
-        
+
         if ($httpResponse->getStatusCode() != 200) {
             throw new \RuntimeException($httpResponse->getStatusMessage(), $httpResponse->getStatusCode());
         }
-        
+
         $response = json_decode($httpResponse->getContent());
         $refunds = array();
-        
+
         foreach ($response->refunds as $refund) {
             $refunds[] = $this->populate($refund);
         }
-        
+
         return new \ArrayIterator($refunds);
     }
-    
+
     public function setOrder(Orders $order)
     {
         $this->order = $order;
     }
-    
+
     public function setPayment(Payment $payment)
     {
         $this->payment = $payment;


### PR DESCRIPTION
According to the documentation of the api, when a customer is created, should return multiple objects, including one called "addresses" But this object is not returned instead is returned objects "shippingAddress" and "BillingAddress", thereby , when running this code for example:
```
$customer = $moip->customers()->setOwnId('sandbox_v2_1401147277')
	->setFullname('Jose Silva')
	->setEmail('sandbox_v2_1401147277@email.com')
	->setBirthDate('1988-12-30')
	->setTaxDocument('33333333333')
	->setPhone(11, 66778899)
	->addAddress('BILLING',
	           'aaaa', 2927,
	           'Itaim', 'Sao Paulo', 'SP',
	           '01234000', 8)
	->addAddress('SHIPPING',
	           'bbbb', 2927,
	           'Itaim', 'Sao Paulo', 'SP',
	           '01234000', 8)
	->create();
```

occurred the following error: `Undefined property: stdClass::$addresses`

With a commit, this error has been corrected!!!