### PR TITLE
Add DateTime object support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.idea/

--- a/src/Moip.php
+++ b/src/Moip.php
@@ -62,7 +62,8 @@ class Moip
     /**
      * Create a new api connection instance.
      *
-     * @return \Moip\Http\HTTPConnection
+     * @param HTTPConnection $http_connection
+     * @return HTTPConnection
      */
     public function createConnection(HTTPConnection $http_connection)
     {

--- a/src/Resource/Customer.php
+++ b/src/Resource/Customer.php
@@ -340,7 +340,7 @@ class Customer extends MoipResource
     /**
      * Set birth date from customer.
      * 
-     * @param \DateTime $birthDate Date of birth of the credit card holder.
+     * @param \DateTime|string $birthDate Date of birth of the credit card holder.
      *
      * @return $this
      */

--- a/src/Resource/Customer.php
+++ b/src/Resource/Customer.php
@@ -164,7 +164,7 @@ class Customer extends MoipResource
     /**
      * Get birth date from customer.
      * 
-     * @return date Date of birth of the credit card holder.
+     * @return \DateTime Date of birth of the credit card holder.
      */
     public function getBirthDate()
     {
@@ -174,7 +174,7 @@ class Customer extends MoipResource
     /**
      * Get phone area code from customer.
      * 
-     * @return insteger DDD telephone.
+     * @return integer DDD telephone.
      */
     public function getPhoneAreaCode()
     {
@@ -302,10 +302,10 @@ class Customer extends MoipResource
     /**
      * Set credit card from customer.
      * 
-     * @param insteger                     $expirationMonth Card expiration month.
-     * @param insteger                     $expirationYear  Year card expiration.
-     * @param insteger                     $number          Card number.
-     * @param insteger                     $cvc             Card Security Code.
+     * @param integer                     $expirationMonth Card expiration month.
+     * @param integer                     $expirationYear  Year card expiration.
+     * @param integer                     $number          Card number.
+     * @param integer                     $cvc             Card Security Code.
      * @param \Moip\Resource\Customer|null $holder          Cardholder.
      *
      * @return $this
@@ -340,7 +340,7 @@ class Customer extends MoipResource
     /**
      * Set birth date from customer.
      * 
-     * @param date $birthDate Date of birth of the credit card holder.
+     * @param \DateTime $birthDate Date of birth of the credit card holder.
      *
      * @return $this
      */

--- a/src/Resource/Customer.php
+++ b/src/Resource/Customer.php
@@ -168,11 +168,7 @@ class Customer extends MoipResource
      */
     public function getBirthDate()
     {
-        $date_string = $this->getIfSet('birthDate');
-        if($date_string){
-            return \DateTime::createFromFormat('Y-m-d', $date_string);
-        }
-        return $this->getIfSet('birthDate');
+        return $this->getIfSetDate('birthDate');
     }
 
     /**

--- a/src/Resource/Customer.php
+++ b/src/Resource/Customer.php
@@ -164,10 +164,14 @@ class Customer extends MoipResource
     /**
      * Get birth date from customer.
      * 
-     * @return \DateTime Date of birth of the credit card holder.
+     * @return \DateTime|null Date of birth of the credit card holder.
      */
     public function getBirthDate()
     {
+        $date_string = $this->getIfSet('birthDate');
+        if($date_string){
+            return \DateTime::createFromFormat('Y-m-d', $date_string);
+        }
         return $this->getIfSet('birthDate');
     }
 
@@ -346,6 +350,12 @@ class Customer extends MoipResource
      */
     public function setBirthDate($birthDate)
     {
+
+        if($birthDate instanceof \DateTime){
+            $birthDate = $birthDate->format('Y-m-d');
+
+        }
+
         $this->data->birthDate = $birthDate;
 
         return $this;

--- a/src/Resource/Entry.php
+++ b/src/Resource/Entry.php
@@ -7,7 +7,7 @@ use stdClass;
 class Entry extends MoipResource
 {
     /**
-     * @const strign
+     * @const string
      */
     const PATH = 'entries';
 
@@ -73,7 +73,7 @@ class Entry extends MoipResource
     /**
      * Get id from entry.
      * 
-     * @return strign Event ID that generated the launch.
+     * @return string Event ID that generated the launch.
      */
     public function getId()
     {

--- a/src/Resource/Entry.php
+++ b/src/Resource/Entry.php
@@ -162,7 +162,7 @@ class Entry extends MoipResource
      */
     public function getScheduledFor()
     {
-        return $this->getIfSet('scheduledFor');
+        return $this->getIfSetDateTime('scheduledFor');
     }
 
     /**
@@ -172,7 +172,7 @@ class Entry extends MoipResource
      */
     public function getSettledAt()
     {
-        return $this->getIfSet('settledAt');
+        return $this->getIfSetDateTime('settledAt');
     }
 
     /**
@@ -182,7 +182,7 @@ class Entry extends MoipResource
      */
     public function getUpdatedAt()
     {
-        return $this->getIfSet('updatedAt');
+        return $this->getIfSetDateTime('updatedAt');
     }
 
     /**
@@ -192,6 +192,6 @@ class Entry extends MoipResource
      */
     public function getCreatedAt()
     {
-        return $this->getIfSet('createdAt');
+        return $this->getIfSetDateTime('createdAt');
     }
 }

--- a/src/Resource/Event.php
+++ b/src/Resource/Event.php
@@ -22,7 +22,7 @@ class Event extends MoipResource
     /**
      * Get event Type.
      * 
-     * @return strign possible values:
+     * @return string possible values:
      *                ORDER.CREATED
      *                ORDER.PAID
      *                ORDER.NOT_PAID
@@ -54,7 +54,7 @@ class Event extends MoipResource
     /**
      * Get creation date of the event.
      * 
-     * @return datetime
+     * @return \DateTime
      */
     public function getCreatedAt()
     {

--- a/src/Resource/Event.php
+++ b/src/Resource/Event.php
@@ -58,7 +58,8 @@ class Event extends MoipResource
      */
     public function getCreatedAt()
     {
-        return $this->data->createdAt;
+        // todo: didn't find Events on documentation but i'm assuming it's a datetime, have to confirm it
+        return $this->getIfSetDateTime('createdAt');
     }
 
     /**

--- a/src/Resource/MoipResource.php
+++ b/src/Resource/MoipResource.php
@@ -13,7 +13,7 @@ abstract class MoipResource implements JsonSerializable
 {
     /**
      * Version of API.
-     * 
+     *
      * @const string
      */
     const VERSION = 'v2';
@@ -35,7 +35,7 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Mount information of a determined object.
-     * 
+     *
      * @param \stdClass $response
      *
      * @return mixed
@@ -44,7 +44,7 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Create a new instance.
-     * 
+     *
      * @param \Moip\Moip $moip
      */
     public function __construct(Moip $moip)
@@ -56,7 +56,7 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Create a new connecttion.
-     * 
+     *
      * @return \Moip\Http\HTTPConnection
      */
     protected function createConnection()
@@ -66,7 +66,7 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Get a key of an object if he exist.
-     * 
+     *
      * @param string         $key
      * @param \stdClass|null $data
      *
@@ -84,8 +84,39 @@ abstract class MoipResource implements JsonSerializable
     }
 
     /**
+     * Get a key, representing a date (Y-m-d), of an object if it exists.
+     * @param string $key
+     * @param stdClass|null $data
+     * @return \DateTime|null
+     */
+    protected function getIfSetDate($key, stdClass $data = null){
+
+        $val = $this->getIfSet($key, $data);
+        if(!empty($val)){
+            return \DateTime::createFromFormat('Y-m-d', $val);
+        }
+        return null;
+
+    }
+
+    /**
+     * Get a key representing a datetime (\Datetime::ATOM), of an object if it exists.
+     * @param string $key
+     * @param stdClass|null $data
+     * @return \DateTime|null
+     */
+
+    protected function getIfSetDateTime($key, stdClass $data = null){
+        $val = $this->getIfSet($key, $data);
+        if(!empty($val)){
+            return \DateTime::createFromFormat(\DateTime::ATOM, $val);
+        }
+        return null;
+    }
+
+    /**
      * Specify data which should be serialized to JSON.
-     * 
+     *
      * @return \stdClass
      */
     public function jsonSerialize()
@@ -95,9 +126,9 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Find by path.
-     * 
+     *
      * @param string $path
-     * 
+     *
      * @return stdClass
      */
     public function getByPath($path)
@@ -116,9 +147,9 @@ abstract class MoipResource implements JsonSerializable
 
     /**
      * Create a new item in Moip.
-     * 
+     *
      * @param string $path
-     * 
+     *
      * @return stdClass
      */
     public function createResource($path)

--- a/src/Resource/Multiorders.php
+++ b/src/Resource/Multiorders.php
@@ -115,7 +115,8 @@ class Multiorders extends MoipResource
      */
     public function getCreatedAt()
     {
-        return $this->getIfSet('createdAt');
+        // todo: didn't find createdAt type on documentation, assuming datetime. Have to confirm
+        return $this->getIfSetDateTime('createdAt');
     }
 
     /**
@@ -125,7 +126,7 @@ class Multiorders extends MoipResource
      */
     public function getUpdatedAt()
     {
-        return $this->getIfSet('updatedAt');
+        return $this->getIfSetDateTime('updatedAt');
     }
 
     /**

--- a/src/Resource/Multiorders.php
+++ b/src/Resource/Multiorders.php
@@ -8,7 +8,7 @@ use stdClass;
 class Multiorders extends MoipResource
 {
     /**
-     * @const strign
+     * @const string
      */
     const PATH = 'multiorders';
 
@@ -24,7 +24,8 @@ class Multiorders extends MoipResource
 
     /**
      * Structure of order.
-     * 
+     *
+     * @param Orders $order
      * @return $this
      */
     public function addOrder(Orders $order)
@@ -59,7 +60,7 @@ class Multiorders extends MoipResource
     /**
      * Get MoIP order id.
      * 
-     * @return strign
+     * @return string
      */
     public function getId()
     {
@@ -185,8 +186,9 @@ class Multiorders extends MoipResource
 
     /**
      * Set own request id. External reference.
-     * 
-     * @param $this
+     *
+     * @param string $ownId
+     * @return $this
      */
     public function setOwnId($ownId)
     {

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -390,7 +390,7 @@ class Orders extends MoipResource
      */
     public function getCreatedAt()
     {
-        return $this->getIfSet('createdAt');
+        return $this->getIfSetDateTime('createdAt');
     }
 
     /**
@@ -400,7 +400,7 @@ class Orders extends MoipResource
      */
     public function getUpdatedAt()
     {
-        return $this->getIfSet('updatedAt');
+        return $this->getIfSetDateTime('updatedAt');
     }
 
     /**

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -8,28 +8,28 @@ use stdClass;
 class Orders extends MoipResource
 {
     /**
-     * @const strign
+     * @const string
      */
     const PATH = 'orders';
 
     /**
      * Defines what kind of payee as pripmary.
      * 
-     * @const strign
+     * @const string
      */
     const RECEIVER_TYPE_PRIMARY = 'PRIMARY';
 
     /**
      * Defines what kind of payee as secundary.
      * 
-     * @const strign
+     * @const string
      */
     const RECEIVER_TYPE_SECONDARY = 'SECONDARY';
 
     /**
      * Currency used in the application.
      * 
-     * @const strign
+     * @const string
      */
     const AMOUNT_CURRENCY = 'BRL';
 
@@ -42,9 +42,9 @@ class Orders extends MoipResource
      * Adds a new item to order.
      * 
      * @param string  $product  Name of the product.
-     * @param int     $quantity Product Quantity.
+     * @param integer     $quantity Product Quantity.
      * @param string  $detail   Additional product description.
-     * @param intefer $price    Initial value of the item.
+     * @param integer $price    Initial value of the item.
      *
      * @return $this
      */
@@ -187,7 +187,7 @@ class Orders extends MoipResource
     /**
      * Get MoIP order id.
      * 
-     * @return strign
+     * @return string
      */
     public function getId()
     {
@@ -441,8 +441,9 @@ class Orders extends MoipResource
 
     /**
      * Set additional value to the item will be added to the value of the items.
-     * 
+     *
      * @param int|float $value additional value to the item.
+     * @return $this
      */
     public function setAddition($value)
     {
@@ -453,8 +454,9 @@ class Orders extends MoipResource
 
     /**
      * Set customer associated with the order.
-     * 
+     *
      * @param \Moip\Resource\Customer $customer customer associated with the request.
+     * @return $this
      */
     public function setCustomer(Customer $customer)
     {
@@ -465,8 +467,9 @@ class Orders extends MoipResource
 
     /**
      * Set discounted value of the item will be subtracted from the total value of the items.
-     * 
+     *
      * @param int|float $value discounted value.
+     * @return $this
      */
     public function setDiscont($value)
     {
@@ -477,8 +480,9 @@ class Orders extends MoipResource
 
     /**
      * Set own request id. external reference.
-     * 
+     *
      * @param string $ownId external reference.
+     * @return $this
      */
     public function setOwnId($ownId)
     {

--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -21,35 +21,35 @@ class Payment extends MoipResource
 
     /**
      * Payment means.
-     * 
+     *
      * @const string
      */
     const METHOD_CREDIT_CARD = 'CREDIT_CARD';
 
     /**
      * Payment means.
-     * 
+     *
      * @const string
      */
     const METHOD_BOLETO = 'BOLETO';
 
     /**
      * Payment means.
-     * 
+     *
      * @const string
      */
     const METHOD_ONLINE_DEBIT = 'ONLINE_DEBIT';
 
     /**
      * Payment means.
-     * 
+     *
      * @const string
      */
     const METHOD_WALLET = 'WALLET';
 
     /**
      * Payment means.
-     * 
+     *
      * @const string
      */
     const METHOD_ONLINE_BANK_DEBIT = 'ONLINE_BANK_DEBIT';
@@ -76,7 +76,7 @@ class Payment extends MoipResource
 
     /**
      * Create a new payment in api MoIP.
-     * 
+     *
      * @return $this
      */
     public function execute()
@@ -112,7 +112,7 @@ class Payment extends MoipResource
 
     /**
      * Get an payment in MoIP.
-     * 
+     *
      * @param string $id Id MoIP payment
      *
      * @return stdClass
@@ -124,7 +124,7 @@ class Payment extends MoipResource
 
     /**
      * Get id MoIP payment.
-     * 
+     *
      *
      * @return \Moip\Resource\Payment
      */
@@ -135,7 +135,7 @@ class Payment extends MoipResource
 
     /**
      * Mount payment structure.
-     * 
+     *
      * @param \stdClass $response
      *
      * @return $this
@@ -160,7 +160,7 @@ class Payment extends MoipResource
 
     /**
      * Refunds.
-     * 
+     *
      * @return Refund
      */
     public function refunds()
@@ -173,7 +173,7 @@ class Payment extends MoipResource
 
     /**
      * Set means of payment.
-     * 
+     *
      * @param \stdClass $fundingInstrument
      *
      * @return $this
@@ -187,8 +187,8 @@ class Payment extends MoipResource
 
     /**
      * Set boleto.
-     * 
-     * @param \DateTime $expirationDate   Expiration date of a billet.
+     *
+     * @param \DateTime|string $expirationDate   Expiration date of a billet.
      * @param string    $logoUri          Logo of billet.
      * @param array     $instructionLines Instructions billet.
      *
@@ -197,6 +197,11 @@ class Payment extends MoipResource
     public function setBoleto($expirationDate, $logoUri, array $instructionLines = [])
     {
         $keys = ['first', 'second', 'third'];
+
+        if($expirationDate instanceof \DateTime){
+            $expirationDate = $expirationDate->format('Y-m-d');
+
+        }
 
         $this->data->fundingInstrument->method = self::METHOD_BOLETO;
         $this->data->fundingInstrument->boleto = new stdClass();
@@ -209,7 +214,7 @@ class Payment extends MoipResource
 
     /**
      * Set credit card holder.
-     * 
+     *
      * @param \Moip\Resource\Customer $holder
      */
     private function setCreditCardHolder(Customer $holder)
@@ -246,9 +251,9 @@ class Payment extends MoipResource
 
     /**
      * Set credit card
-     * Credit card used in a payment. 
+     * Credit card used in a payment.
      * The card when returned within a parent resource is presented in its minimum representation.
-     * 
+     *
      * @param int                     $expirationMonth Card expiration month
      * @param int                     $expirationYear  Year of card expiration.
      * @param int                     $number          Card number.
@@ -284,15 +289,20 @@ class Payment extends MoipResource
 
     /**
      * Set payment means made available by banks.
-     * 
+     *
      * @param string    $bankNumber     Bank number. Possible values: 001, 237, 341, 041.
-     * @param \DateTime $expirationDate Date of expiration debit.
+     * @param \DateTime|string $expirationDate Date of expiration debit.
      * @param string    $returnUri      Return Uri.
      *
      * @return $this
      */
     public function setOnlineBankDebit($bankNumber, $expirationDate, $returnUri)
     {
+
+        if($expirationDate instanceof \DateTime){
+            $expirationDate = $expirationDate->format('Y-m-d');
+
+        }
         $this->data->fundingInstrument->method = self::METHOD_ONLINE_BANK_DEBIT;
         $this->data->fundingInstrument->onlineBankDebit = new stdClass();
         $this->data->fundingInstrument->onlineBankDebit->bankNumber = $bankNumber;
@@ -304,7 +314,7 @@ class Payment extends MoipResource
 
     /**
      * Set Multiorders.
-     * 
+     *
      * @param \Moip\Resource\Multiorders $multiorder
      */
     public function setMultiorder(Multiorders $multiorder)
@@ -314,7 +324,7 @@ class Payment extends MoipResource
 
     /**
      * Set order.
-     * 
+     *
      * @param \Moip\Resource\Orders $order
      *
      * @return $this

--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -272,6 +272,8 @@ class Payment extends MoipResource
 
     /**
      * Set installment count.
+     * @param int $installmentCount
+     * @return $this
      */
     public function setInstallmentCount($installmentCount)
     {

--- a/src/Resource/Refund.php
+++ b/src/Resource/Refund.php
@@ -10,7 +10,7 @@ use stdClass;
 class Refund extends MoipResource
 {
     /**
-     * @const strign
+     * @const string
      */
     const PATH = 'refunds';
 


### PR DESCRIPTION
Esse pull request permite que se use objetos DateTime onde strings de data eram usadas. 

Funções que recebiam strings agora aceitam strings ou objetos DateTime. Funções que retornavam strings de data agora retornam objetos DateTime.
Eu tentei fazer um commit por classe, para facilitar a integração.

Eu não tenho muita experiência contribuindo para projetos open-source, então se tiver algo que precise ser mudado é só falar :D 