### PR TITLE
 - Orders class's Method addReceiver updated to accept a fixed amount…

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -74,7 +74,7 @@ class Orders extends MoipResource
         $receiver = new stdClass();
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
-        if(!empty($fixed)) {
+        if (!empty($fixed)) {
             $receiver->amount->fixed = $fixed;
         }
         $receiver->type = $type;

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -66,10 +66,9 @@ class Orders extends MoipResource
      *
      * @param string $moipAccount Id MoIP MoIP account that will receive payment values.
      * @param string $type        Define qual o tipo de recebedor do pagamento, valores possíveis: PRIMARY, SECONDARY.
-     *
-     * @return $this
+     * @return int   $fixed       Initial value that the receiver will receive.
      */
-    public function addReceiver($moipAccount, $type = self::RECEIVER_TYPE_PRIMARY, $fixed)
+    public function addReceiver($moipAccount, $type = Orders::RECEIVER_TYPE_PRIMARY, $fixed)
     {
         $receiver = new stdClass();
         $receiver->moipAccount = new stdClass();

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -69,11 +69,14 @@ class Orders extends MoipResource
      *
      * @return $this
      */
-    public function addReceiver($moipAccount, $type = self::RECEIVER_TYPE_PRIMARY)
+    public function addReceiver($moipAccount, $type = self::RECEIVER_TYPE_PRIMARY, $fixed)
     {
         $receiver = new stdClass();
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
+        if(!empty($fixed)) {
+            $receiver->amount->fixed = $fixed;
+        }
         $receiver->type = $type;
 
         $this->data->receivers[] = $receiver;

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -66,7 +66,8 @@ class Orders extends MoipResource
      *
      * @param string $moipAccount Id MoIP MoIP account that will receive payment values.
      * @param string $type        Define qual o tipo de recebedor do pagamento, valores possíveis: PRIMARY, SECONDARY.
-     * @return int   $fixed       Initial value that the receiver will receive.
+     * @param int   $fixed       Value that the receiver will receive.
+     * @return $this
      */
     public function addReceiver($moipAccount, $type = Orders::RECEIVER_TYPE_PRIMARY, $fixed)
     {


### PR DESCRIPTION
 - Orders class's Method addReceiver updated to accept a fixed amount in a payment to a specific receiver(primary or secondary). For example, I could say that the primary receiver will receive R$10,00 and the secondary receiver will receive R$90,00. In this case, I could create a order like below:
$order = $moip->orders()->setOwnId('seu_identificador_proprio_teste_001')
                  ->addItem('Reserva da suíte xyz do motel abc', 1, 'Suite', $price)
                  ->setCustomer($customer)
                  ->addReceiver($idReceiverPrimary, Orders::RECEIVER_TYPE_PRIMARY, $valueA)
                  ->addReceiver($idReceiverSecondary, Orders::RECEIVER_TYPE_SECONDARY, $valueB)
                  ->create();