### PR TITLE
Ajustes no retorno da taxa da Moip

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -236,7 +236,7 @@ class Orders extends MoipResource
      */
     public function getAmountFees()
     {
-        return $this->getIfSet('feed', $this->data->amount);
+        return $this->getIfSet('fees', $this->data->amount);
     }
 
     /**


### PR DESCRIPTION
O retorno estava incorreto `feed` => `fees`.