### PR TITLE
Fix Creating default object from empty value in Order@addReceiver

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -87,6 +87,7 @@ class Orders extends MoipResource
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
         if (!empty($fixed)) {
+        	$receiver->amount = new stdClass();
             $receiver->amount->fixed = $fixed;
         }
         $receiver->type = $type;


### PR DESCRIPTION
O objeto não está sendo iniciado na linha 90 do `Moip\Resource\Orders.php`.

Adendo: Acho estranho nunca terem pego este erro. Ninguém usa isso?