### PR TITLE
[Payment] Inclusão de método para setar o statementDescriptor

### DIFF
--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -393,6 +393,20 @@ class Payment extends MoipResource
     }
 
     /**
+     * Set statement descriptor.
+     *
+     * @param string $statementDescriptor
+     *
+     * @return $this
+     */
+    public function setStatementDescriptor($statementDescriptor)
+    {
+        $this->data->statementDescriptor = $statementDescriptor;
+
+        return $this;
+    }
+
+    /**
      * Set payment means made available by banks.
      *
      * @param string           $bankNumber     Bank number. Possible values: 001, 237, 341, 041.


### PR DESCRIPTION
Conforme documentação https://dev.moip.com.br/v2.0/reference#criar-pagamento é possível enviar o nome que aparecerá na fatura do cartão de crédito (statementDescriptor).

Nesse commit implementei um método para setar essa propriedade.