### PR TITLE
Pegando corretamente o retorno da requisição de criar pedido

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -141,8 +141,7 @@ class Orders extends MoipResource
         $this->orders->data->amount->subtotals = $response->amount->subtotals;
 
         $customer = new Customer($this->moip);
-        $customer->populate($response->customer);
-        $this->orders->data->customer = $customer;
+        $this->orders->data->customer = $customer->populate($response->customer);
 
         $this->orders->data->payments = $this->structure($response, Payment::PATH, Payment::class);
         $this->orders->data->refunds = $this->structure($response, Refund::PATH, Refund::class);

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -87,7 +87,7 @@ class Orders extends MoipResource
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
         if (!empty($fixed)) {
-        	$receiver->amount = new stdClass();
+            $receiver->amount = new stdClass();
             $receiver->amount->fixed = $fixed;
         }
         $receiver->type = $type;


### PR DESCRIPTION
O método populate não salva o retorno na variável $customer, e por esse motivo, quando um pedido (order) é criado, o retorno da criação da Order vem com um cliente com dados vazios.