### PR TITLE
Adição de método setCustomerId

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -478,6 +478,23 @@ class Orders extends MoipResource
 
         return $this;
     }
+    
+    /**
+     * Set customer id associated with the order.
+     *
+     * @param string $id Customer's id.
+     *
+     * @return $this
+    */
+    public function setCustomerId($id)
+    {
+        if (!isset($this->data->customer)) {
+            $this->data->customer = new stdClass();
+        }
+        $this->data->customer->id = $id;
+
+        return $this;
+    }
 
     /**
      * Set discounted value of the item will be subtracted from the total value of the items.

--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -87,7 +87,7 @@ class Orders extends MoipResource
         $receiver->moipAccount = new stdClass();
         $receiver->moipAccount->id = $moipAccount;
         if (!empty($fixed)) {
-        	$receiver->amount = new stdClass();
+            $receiver->amount = new stdClass();
             $receiver->amount->fixed = $fixed;
         }
         $receiver->type = $type;
@@ -478,14 +478,14 @@ class Orders extends MoipResource
 
         return $this;
     }
-    
+
     /**
      * Set customer id associated with the order.
      *
      * @param string $id Customer's id.
      *
      * @return $this
-    */
+     */
     public function setCustomerId($id)
     {
         if (!isset($this->data->customer)) {


### PR DESCRIPTION
Método "setCustomerId" adicionado para que a criação de pedido possa ser feita de forma simplificada, de acordo com o que já existe na API. Exemplo:

$order = $v_Moip->orders()->setOwnId("1")
->addItem("Bicicleta", 1, "sku1", 1000)
->setShippingAmount(0)
->setCustomerId("CUS-7QADQEMQ8FU1");
->create();