### PR TITLE
Fix getIfSetDateTime() to return correctly DateTime object

### DIFF
--- a/src/Resource/MoipResource.php
+++ b/src/Resource/MoipResource.php
@@ -129,7 +129,13 @@ abstract class MoipResource implements JsonSerializable
      */
     protected function getIfSetDateTime($key, stdClass $data = null)
     {
-        return $this->getIfSetDateFmt($key, \DateTime::ATOM, $data);
+        $rawDateTime = $this->getIfSet($key, $data);
+
+        if (!empty($rawDateTime)) {
+            $dateTime = new \DateTime($rawDateTime);
+
+            return $dateTime ? $dateTime : null;
+        }
     }
 
     /**


### PR DESCRIPTION
Corrigido método getIfSetDateTime() do **MoipResource.php**, que agora retorna um DateTime com os dados corretos.

Acho estranho esse método estar errado, gostaria da confirmação de alguém, por acaso alguém já usou este método?

Eu testei no meu projeto Laravel 5.4 (PHP 7.0). 

Gostaria de saber se devo testar em outras versões, como devo testar? 

Gostaria de garantir o funcionamento em todas as versões. 

Abraços!