### PR TITLE
Inicializando variável para remover um E_NOTICE

### DIFF
--- a/src/Resource/MoipResource.php
+++ b/src/Resource/MoipResource.php
@@ -244,8 +244,10 @@ abstract class MoipResource implements JsonSerializable
             throw new Exceptions\UnautorizedException();
         } elseif ($code >= 400 && $code <= 499) {
             $errors = Exceptions\Error::parseErrors($response_body);
+            
             throw new Exceptions\ValidationException($code, $errors);
         }
+        
         throw new Exceptions\UnexpectedException();
     }
 

--- a/src/Resource/MoipResource.php
+++ b/src/Resource/MoipResource.php
@@ -244,10 +244,10 @@ abstract class MoipResource implements JsonSerializable
             throw new Exceptions\UnautorizedException();
         } elseif ($code >= 400 && $code <= 499) {
             $errors = Exceptions\Error::parseErrors($response_body);
-            
+
             throw new Exceptions\ValidationException($code, $errors);
         }
-        
+
         throw new Exceptions\UnexpectedException();
     }
 

--- a/src/Resource/MoipResource.php
+++ b/src/Resource/MoipResource.php
@@ -133,6 +133,7 @@ abstract class MoipResource implements JsonSerializable
     {
         $rawDateTime = $this->getIfSet($key, $data);
 
+        $dateTime = null;
         if (!empty($rawDateTime)) {
             $dateTime = new \DateTime($rawDateTime);
         }


### PR DESCRIPTION
A variável $rawDateTime, quando vazia nunca inicializa a variável $dateTime, gerando um NOTICE no PHP.
Essa correção inicializa a variável $dateTime com NULL, eliminando o NOTICE.