### PR TITLE
Compatibilidade com PHP 5.6

### DIFF
--- a/src/Auth/Connect.php
+++ b/src/Auth/Connect.php
@@ -500,7 +500,7 @@ class Connect implements Authentication, JsonSerializable
      *
      * @return \Moip\Auth\Connect
      */
-    public function setEndpoint(string $endpoint)
+    public function setEndpoint($endpoint)
     {
         if (!in_array($endpoint, [self::ENDPOINT_SANDBOX, self::ENDPOINT_PRODUCTION])) {
             throw new InvalidArgumentException('Endpoint inválido.');
@@ -536,7 +536,7 @@ class Connect implements Authentication, JsonSerializable
      *
      * @return \Moip\Auth\Connect
      */
-    public function setCode(string $code)
+    public function setCode($code)
     {
         $this->code = $code;
 


### PR DESCRIPTION
Exception que é lançada utilizando PHP 5.6.x quando uma instância da classe Moip\Auth\Connect é criada:

> Argument 1 passed to Moip\Auth\Connect::setEndpoint() must be an instance of Moip\Auth\string, string given, called in /Users/lucascolette/.../vendor/moip/moip-sdk-php/src/Auth/Connect.php on line 176