### PR TITLE
Atualizando o Link do boleto

### DIFF
--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -274,7 +274,7 @@ class Payment extends MoipResource
      */
     public function getHrefBoleto()
     {
-        return $this->getIfSet('_links')->payBoleto->redirectHref;
+        return $this->getIfSet('_links')->checkout->payBoleto->redirectHref;
     }
 
     /**


### PR DESCRIPTION
Atualizei o Link para o Boleto, estava dando erro, tinha o elemento **checkout** faltando.