### PR TITLE
setTaxDocument, setFullname replaced by setHolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,8 +656,7 @@ $bank_account = $moip->bank_accounts()
         ->setAccountNumber('12345678')
         ->setAccountCheckNumber('7')
         ->setType('CHECKING')
-        ->setTaxDocument('CPF', '622.134.533-22')
-        ->setFullname('Demo Moip')
+        ->setHolder('Demo Moip', '622.134.533-22', 'CPF')
         ->create($account_id);
         
 print_r($bank_account);

--- a/src/Resource/BankAccount.php
+++ b/src/Resource/BankAccount.php
@@ -202,30 +202,6 @@ class BankAccount extends MoipResource
     }
 
     /**
-     * Set holder full name.
-     *
-     * @param string $fullname Holder full name.
-     *
-     * @return $this
-     */
-    public function setFullname($fullname)
-    {
-        $this->data->holder->fullname = $fullname;
-
-        return $this;
-    }
-
-    /**
-     * Returns holder full name.
-     *
-     * @return string
-     */
-    public function getFullname()
-    {
-        return $this->getIfSet('fullname', $this->data->holder);
-    }
-
-    /**
      * Set holder.
      *
      * @param string $fullname Holder full name.
@@ -245,19 +221,13 @@ class BankAccount extends MoipResource
     }
 
     /**
-     * Set holder tax document.
+     * Returns holder full name.
      *
-     * @param string $type   Document type (CPF or CNPJ).
-     * @param string $number Document number.
-     *
-     * @return $this
+     * @return string
      */
-    public function setTaxDocument($type, $number)
+    public function getFullname()
     {
-        $this->data->holder->taxDocument->type = $type;
-        $this->data->holder->taxDocument->number = $number;
-
-        return $this;
+        return $this->getIfSet('fullname', $this->data->holder);
     }
 
     /**

--- a/tests/Resource/BankAccountTest.php
+++ b/tests/Resource/BankAccountTest.php
@@ -19,8 +19,7 @@ class BankAccountTest extends TestCase
             ->setAccountNumber('12345678')
             ->setAccountCheckNumber('7')
             ->setType('CHECKING')
-            ->setTaxDocument('CPF', '622.134.533-22')
-            ->setFullname('Demo Moip')
+            ->setHolder('Demo Moip', '622.134.533-22', 'CPF')
             ->create($account_id);
 
         return $bank_account;
@@ -47,10 +46,8 @@ class BankAccountTest extends TestCase
         $this->assertEquals('12345678', $bank_account->getAccountNumber());
         $this->assertEquals('7', $bank_account->getAccountCheckNumber());
         $this->assertEquals('Demo Moip', $bank_account->getFullname());
-
-        $taxDocument = $bank_account->getTaxDocument();
-        $this->assertEquals('CPF', $taxDocument->type);
-        $this->assertEquals('622.134.533-22', $taxDocument->number);
+        $this->assertEquals('CPF', $bank_account->getTaxDocumentType());
+        $this->assertEquals('622.134.533-22', $bank_account->getTaxDocumentNumber());
     }
 
     public function testShouldUpdateBankAccount()


### PR DESCRIPTION
PR #195/#205 extension, BankAccount class changes.

Updated documentation and tests to work with setHolder, getTaxDocumentType and getTaxDocumentNumber methods (created at PR #205). Also removed setTaxDocument and setFullname (these methods probably would be useless now).

What this PR change?
- Methods setTaxDocument and setFullname removed
- Updated bank account documentation to use setHolder instead of setTaxDocument and setFullname
- Updated bank account tests to use setHolder, getTaxDocumentType and getTaxDocumentNumber instead of setTaxDocument and setFullname