### PR TITLE
[PRE-RELEASE/HOTFIX] Remove duplicated bank accounts reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ $transfer = $this->moip->transfers()->revert($transfer_id);
 ### Criação
 ```php
 $account_id = 'MPA-05E8C79EAAAA';
-$bank_account = $moip->bank_accounts()
+$bank_account = $moip->bankaccount()
         ->setBankNumber('237')
         ->setAgencyNumber('12345')
         ->setAgencyCheckNumber('0')
@@ -666,7 +666,7 @@ print_r($bank_account);
 #### Conta bancária específica
 ```php
 $bank_account_id = 'BKA-397X21X1G6LT';
-$bank_account = $moip->bank_accounts()->get($bank_account_id);
+$bank_account = $moip->bankaccount()->get($bank_account_id);
 
 print_r($bank_account);
 ```
@@ -674,7 +674,7 @@ print_r($bank_account);
 #### Todas contas bancárias
 ```php
 $account_id = 'MPA-05E8C79EAAAA';
-$bank_accounts = $moip->bank_accounts()->getList($account_id)->getBankAccounts();
+$bank_accounts = $moip->bankaccount()->getList($account_id)->getBankAccounts();
 
 print_r($bank_accounts);
 ```
@@ -682,13 +682,13 @@ print_r($bank_accounts);
 ### Exclusão
 ```php
 $bank_account_id = 'BKA-397X21X1G6LT';
-$moip->bank_accounts()->delete($bank_account_id);
+$moip->bankaccount()->delete($bank_account_id);
 ```
 
 ### Atualização
 ```php
 $bank_account_id = 'BKA-397X21X1G6LT';
-$bank_account = $moip->bank_accounts()->get($bank_account_id);
+$bank_account = $moip->bankaccount()->get($bank_account_id);
 $bank_account->setAccountCheckNumber('7');
 $bank_account->update();
 

--- a/src/Moip.php
+++ b/src/Moip.php
@@ -141,16 +141,6 @@ class Moip
     }
 
     /**
-     * Create a new BankAccount instance.
-     *
-     * @return \Moip\Resource\BankAccount
-     */
-    public function bank_accounts()
-    {
-        return new BankAccount($this);
-    }
-
-    /**
      * Create a new Entry instance.
      *
      * @return \Moip\Resource\Entry

--- a/tests/Resource/BankAccountListTest.php
+++ b/tests/Resource/BankAccountListTest.php
@@ -12,7 +12,7 @@ class BankAccountListTest extends TestCase
 
         $account_id = 'MPA-3C5358FF2296';
 
-        $bank_accounts = $this->moip->bank_accounts()->getList($account_id);
+        $bank_accounts = $this->moip->bankaccount()->getList($account_id);
 
         $this->assertNotNull($bank_accounts->getBankAccounts());
     }

--- a/tests/Resource/BankAccountTest.php
+++ b/tests/Resource/BankAccountTest.php
@@ -12,7 +12,7 @@ class BankAccountTest extends TestCase
 
         $account_id = 'MPA-3C5358FF2296';
 
-        $bank_account = $this->moip->bank_accounts()
+        $bank_account = $this->moip->bankaccount()
             ->setBankNumber('237')
             ->setAgencyNumber('12345')
             ->setAgencyCheckNumber('0')
@@ -37,7 +37,7 @@ class BankAccountTest extends TestCase
 
         $this->mockHttpSession($this->body_bank_account_create);
 
-        $bank_account = $this->moip->bank_accounts()->get($bank_account_id);
+        $bank_account = $this->moip->bankaccount()->get($bank_account_id);
         $this->assertEquals($bank_account_id, $bank_account->getId());
         $this->assertEquals('CHECKING', $bank_account->getType());
         $this->assertEquals('237', $bank_account->getBankNumber());
@@ -56,7 +56,7 @@ class BankAccountTest extends TestCase
 
         $this->mockHttpSession($this->body_bank_account_update);
 
-        $bank_account = $this->moip->bank_accounts()
+        $bank_account = $this->moip->bankaccount()
             ->setAccountCheckNumber('8')
             ->update($bank_account_id);
 


### PR DESCRIPTION
- remove `bank_accounts()` in favour of the already existing `bankaccount()`
- update README accordingly