### PR TITLE
Support PHPUnit 5 and 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "rmccue/requests": ">=1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4",
         "codacy/coverage": "dev-master"
     },
     "autoload": {

--- a/tests/MoipTest.php
+++ b/tests/MoipTest.php
@@ -108,6 +108,8 @@ class MoipTest extends TestCase
 
     /**
      * MoipTest if \Moip\Exceptios\UnautorizedException is thrown.
+     *
+     * @expectedException Moip\Exceptions\UnautorizedException
      */
     public function testShouldRaiseUnautorizedException()
     {
@@ -116,7 +118,6 @@ class MoipTest extends TestCase
 
             return;
         }
-        $this->setExpectedException('\Moip\Exceptions\UnautorizedException');
         $body = '{ "ERROR" : "Token or Key are invalids" }'; // the body is not processed in any way, i'm putting this for completeness
         $this->mockHttpSession($body, 401);
         $this->moip->orders()->get('ORD-1AWC30TWYZMX');
@@ -124,6 +125,8 @@ class MoipTest extends TestCase
 
     /**
      * MoipTest if UnexpectedException is thrown when 500 http status code is returned.
+     *
+     * @expectedException Moip\Exceptions\UnexpectedException
      */
     public function testShouldRaiseUnexpectedException500()
     {
@@ -132,7 +135,6 @@ class MoipTest extends TestCase
 
             return;
         }
-        $this->setExpectedException('\Moip\Exceptions\UnexpectedException');
         $this->mockHttpSession('error', 500); // the body isn't processed
         $this->moip->orders()->get('ORD-1AWC30TWYZMX');
     }
@@ -147,7 +149,7 @@ class MoipTest extends TestCase
 
             return;
         }
-        $sess = $this->getMock('\Requests_Session');
+        $sess = $this->getMockBuilder('\Requests_Session')->getMock();
         $sess->expects($this->once())->method('request')->willThrowException(new Requests_Exception('test error',
             'test'));
         $this->moip->setSession($sess);

--- a/tests/Resource/RefundTest.php
+++ b/tests/Resource/RefundTest.php
@@ -204,7 +204,7 @@ class RefundTest extends TestCase
         $order = $this->createOrder()->create();
         $this->mockHttpSession($this->body_billet_pay);
         $payment = $order->payments()
-            ->setBoleto(new \DateTime('today +1day'),'http://dev.moip.com.br/images/logo-header-moip.png')
+            ->setBoleto(new \DateTime('today +1day'), 'http://dev.moip.com.br/images/logo-header-moip.png')
             ->execute();
         $this->mockHttpSession('');
         $payment->authorize();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,13 +6,13 @@ use Moip\Auth\OAuth;
 use Moip\Moip;
 use Moip\Resource\Customer;
 use Moip\Resource\Orders;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Requests_Response;
 
 /**
  * class TestCase.
  */
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     /**
      * Variables representing the test modes. On MOCK mode no http request will be made.
@@ -254,7 +254,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
             $auth = new OAuth($moip_access_token);
         } else {
             $this->sandbox_mock = self::MOCK;
-            $auth = $this->getMock('\Moip\Contracts\Authentication');
+            $auth = $this->getMockBuilder('\Moip\Contracts\Authentication')->getMock();
         }
         $this->moip = new Moip($auth, Moip::ENDPOINT_SANDBOX);
     }
@@ -285,7 +285,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         $resp = new Requests_Response();
         $resp->body = $body;
         $resp->status_code = $status_code;
-        $sess = $this->getMock('\Requests_Session');
+        $sess = $this->getMockBuilder('\Requests_Session')->getMock();
         $sess->expects($this->once())->method('request')->willReturn($resp);
         $this->moip->setSession($sess);
     }


### PR DESCRIPTION
I've added support o `PHPUnit` version 5 and 6.

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support the `PHPUnit\Framework\TestCase`.

PS: I won't apply [this Style CI changes](https://styleci.io/analyses/qyng7D). There are not related to this PR :sweat_smile: 