### PR TITLE
Parâmetro para o método setDelayCapture() da classe Moip\Resource\Payment

### DIFF
--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -527,11 +527,12 @@ class Payment extends MoipResource
     /**
      * Turns on a delay on credit card payment capture (pre-authorization).
      *
+     * @paramm $value bool
      * @return $this
      */
-    public function setDelayCapture()
+    public function setDelayCapture($value = true)
     {
-        $this->data->delayCapture = true;
+        $this->data->delayCapture = $value;
 
         return $this;
     }

--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -527,7 +527,7 @@ class Payment extends MoipResource
     /**
      * Turns on a delay on credit card payment capture (pre-authorization).
      *
-     * @paramm $value bool
+     * @param $value bool
      * @return $this
      */
     public function setDelayCapture($value = true)


### PR DESCRIPTION
Acho necessário pois no formato atual creio que induza ao erro (aconteceu comigo).

No caso, estava utilizando ->setDelayCapture(false), o que não funciona. O valor sempre é true.

Att.

