### PR TITLE
Test against PHP 7.1 and 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
With the release of [`PHP 7.2`](http://php.net/archive/2017.php#id2017-11-30-1), would be interesting to test. I've also added `PHP 7.1` tests.