### PR TITLE
adding getPasswordLink() method to Account class

### DIFF
--- a/src/Resource/Account.php
+++ b/src/Resource/Account.php
@@ -352,6 +352,16 @@ class Account extends MoipResource
     {
         return $this->getIfSet('confirmed', $this->data->email);
     }
+    
+    /**
+     * Get password Link.
+     *
+     * @return stdClass
+     */
+     public function getPasswordLink()
+         {
+             return $this->getIfSet('_links')->setPassword->href;
+         }
 
     /**
      * Get account type.


### PR DESCRIPTION
Adicionando método para obter o link de definição de senha para uma conta Moip recém criada.