### PR TITLE
Novo método para retornar os hrefs após gerar uma Order (Checkout Moip)

### DIFF
--- a/src/Resource/Orders.php
+++ b/src/Resource/Orders.php
@@ -558,6 +558,17 @@ class Orders extends MoipResource
     }
 
     /**
+     * Get checkout href types for Checkout Moip.
+     * 
+     *
+     * @return stdClass
+     */
+    public function getCheckoutTypesHref()
+    {
+        return $this->getIfSet('_links')->checkout;
+    }
+
+    /**
      * Create a new Orders list instance.
      *
      * @return \Moip\Resource\OrdersList


### PR DESCRIPTION
Olá Pessoal,

Estou integrando o Moip em um projeto aqui que será Checkout Moip, com isso, após eu ter criado a order, não consegui acessar a propriedade `payCheckout->redirectHref` pra mim redirecionar o usuário. 

Com isso acabei pesquisando e encontrei o método `getLinks()` em uma issue aqui no github, porém também não consegui acessar pois está privada.

Enfim, essa foi a solução que eu encontrei, caso já exista algo similar a isso, poderia me informar por favor? rsrs

Valeu pessoal!! 