### PR TITLE
Refactor(setDeviceFingerprint method): makes latitude and longitude parameters optional

### DIFF
--- a/src/Resource/Payment.php
+++ b/src/Resource/Payment.php
@@ -575,7 +575,7 @@ class Payment extends MoipResource
      *
      * @return $this
      */
-    public function setDeviceFingerprint($ip, $latitude, $longitude, $userAgent, $fingerprint)
+    public function setDeviceFingerprint($ip, $userAgent, $fingerprint, $latitude = null, $longitude = null,)
     {
         $this->data->device->geolocation = new stdClass();
         $this->data->device->geolocation->latitude = $latitude;


### PR DESCRIPTION
## History
Our risk analysis department instructs sellers to send the buyer’s device data when creating the payment so that it can be used to ensure greater security in the transactional process and consequently improve the conversion of our customers. Therefore, this PR includes in our SDK developed in PHP, the methods and functions necessary for the salespeople to be able to request and send us such information.

## Description
This change makes the latitude and longitude parameters optional in the setDeviceFingerprint() method of the Payment class

## Reference
Technical reference about this feature: https://docs.moip.com.br/reference#criar-pagamento

## Tasks
- [x] Sets $latitude and $longitude parameters as null 

